### PR TITLE
Support field errors and error message rendering

### DIFF
--- a/implementation/wp-includes/fields-api/class-wp-fields-api-control.php
+++ b/implementation/wp-includes/fields-api/class-wp-fields-api-control.php
@@ -87,6 +87,14 @@ class WP_Fields_API_Control extends WP_Fields_API_Container {
 	private static $printed_templates = array();
 
 	/**
+	 * Store save errors for this control
+	 *
+	 * @access public
+	 * @var WP_Error
+	 */
+	public $error = null;
+
+	/**
 	 * Secondary constructor; Any supplied $args override class property defaults.
 	 *
 	 * @param string $object_type   Object type.
@@ -364,6 +372,9 @@ class WP_Fields_API_Control extends WP_Fields_API_Container {
 			'id'    => 'fields-control-' . str_replace( '[', '-', str_replace( ']', '', $this->id ) ),
 			'class' => 'fields-control fields-control-' . $this->type,
 		);
+		if ( is_wp_error( $this->error ) ) {
+			$attrs['class'] .= ' fields-error fields-error-code-' . esc_attr( $this->error->get_error_code() );
+		}
 
 		$input_attrs = $this->get_input_attrs();
 
@@ -411,6 +422,11 @@ class WP_Fields_API_Control extends WP_Fields_API_Container {
 		}
 		?>
 		<input type="<?php echo esc_attr( $this->type ); ?>" <?php $this->input_attrs(); ?> value="<?php echo esc_attr( $this->value() ); ?>" <?php $this->link(); ?> />
+
+		<?php if ( is_wp_error( $this->error ) ) : ?>
+			<span class="field-error-text"><?php echo esc_html( $this->error->get_error_message() ); ?></span>
+		<?php endif; ?>
+
 		<?php
 
 	}

--- a/implementation/wp-includes/fields-api/class-wp-fields-api-form.php
+++ b/implementation/wp-includes/fields-api/class-wp-fields-api-form.php
@@ -202,7 +202,7 @@ class WP_Fields_API_Form extends WP_Fields_API_Container {
 	 * @param int|null    $item_id     Item ID
 	 * @param string|null $object_subtype Object subtype
 	 *
-	 * @return int|WP_Error|null New item ID, WP_Error if there was a problem, null if no $item_id used
+	 * @return bool|array false if saving doesn't occur, true if there are no errors, array if there are error(s)
 	 */
 	public function save_fields( $item_id = null, $object_subtype = null ) {
 


### PR DESCRIPTION
This PR does the following:
- Sanitize returning a WP_Error counts as an error
- Store error in control object
- When a form is saved, return errors if they exist
- Allow short circuiting so if one error occurs nothing will be save.
- Render field errors within control
