### PR TITLE
Basic dev doc.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,38 @@
+# Developing
+
+## Configuring your workspace (Scotchbox)
+<!-- 
+1. Install [scotchbox](https://box.scotch.io)
+2. `vagrant ssh`
+3. Install subversion (`sudo apt-get install subversion`)
+4. `composer global require "phpunit/phpunit=4.1.*"` 
+	(`sudo composer self-update` if prompted).
+5. `bash bin/install-wp-tests.sh wptest root root localhost` (where `wptest`
+	can be whatever DB name you want).
+6. `npm install`
+7. `composer install`
+8. Done! -->
+
+## Configuring your workspace (Manual)
+
+1. Install [composer](https://getcomposer.org/download/) and
+	[npm](https://www.npmjs.com/get-npm).
+2. `composer install` and `npm install` in this directory to get necessary dev
+	dependencies.
+
+At this point, you can lint your code by running the `bin/phpcs.sh` file from
+this directory.
+
+## Run tests
+
+1. Install [PHPUnit](https://phpunit.de/manual/current/en/installation.html)
+2. Setup a dev SQL server
+3. `bin/install-wp-tests.sh wptest root root location_of_db` (where `wptest`
+	can be whatever DB name you want). `location_of_db` would probably be
+	`localhost`.
+
+## Usage
+
+You can run tests at any time using the `phpunit` command.
+
+You can lint at any time running via `bash bin/phpcs.sh` (or `grunt phpcs`).

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
 # Developing
 
-## Configuring your workspace (Manual)
+## Configuring your workspace
 
 1. Install [composer](https://getcomposer.org/download/) and
 	[npm](https://www.npmjs.com/get-npm).
@@ -8,12 +8,33 @@
 	dependencies.
 
 At this point, you can lint your code by running the `bin/phpcs.sh` file from
-this directory. 
+this directory.
+
+### In-editor linting (Sublime)
+
+If you would like to lint automatically in Sublime 3:
+
+1. Install (via Package Control) `SublimeLinter` and `SublimeLinter-phpcs`.
+2. Install global PHPCS using composer (`composer global require "squizlabs/php_codesniffer=*"`)
+3. Ensure your composer directory (generally `~/.composer/vendor/bin`) is in `$PATH`.
+4. Add some configuration to Sublime's `SublimeLinter.sublime-settings`:
+	```
+	"chdir": "${project}",
+	"cmd": "vendor/bin/phpcs"
+	"standard": [
+        "${project}/phpcs.xml",
+        "${directory}/phpcs.xml",
+        "${project}/phpcs.ruleset.xml",
+        "${directory}/phpcs.ruleset.xml",
+    ]
+    ```
+
+And linting should now work, in-editor.
 
 ## Run tests
 
 1. Install [PHPUnit](https://phpunit.de/manual/current/en/installation.html)
-2. Setup a dev SQL server
+2. Setup a dev SQL server (perhaps using [VVV](https://varyingvagrantvagrants.org/))
 3. `bin/install-wp-tests.sh wptest db_user db_pass db_location` (where `wptest`
 	can be whatever DB name you want). User, pass, and location are
 	`root`, `password`, and `localhost` on my box respectively.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,18 +1,5 @@
 # Developing
 
-## Configuring your workspace (Scotchbox)
-<!-- 
-1. Install [scotchbox](https://box.scotch.io)
-2. `vagrant ssh`
-3. Install subversion (`sudo apt-get install subversion`)
-4. `composer global require "phpunit/phpunit=4.1.*"` 
-	(`sudo composer self-update` if prompted).
-5. `bash bin/install-wp-tests.sh wptest root root localhost` (where `wptest`
-	can be whatever DB name you want).
-6. `npm install`
-7. `composer install`
-8. Done! -->
-
 ## Configuring your workspace (Manual)
 
 1. Install [composer](https://getcomposer.org/download/) and
@@ -21,15 +8,15 @@
 	dependencies.
 
 At this point, you can lint your code by running the `bin/phpcs.sh` file from
-this directory.
+this directory. 
 
 ## Run tests
 
 1. Install [PHPUnit](https://phpunit.de/manual/current/en/installation.html)
 2. Setup a dev SQL server
-3. `bin/install-wp-tests.sh wptest root root location_of_db` (where `wptest`
-	can be whatever DB name you want). `location_of_db` would probably be
-	`localhost`.
+3. `bin/install-wp-tests.sh wptest db_user db_pass db_location` (where `wptest`
+	can be whatever DB name you want). User, pass, and location are
+	`root`, `password`, and `localhost` on my box respectively.
 
 ## Usage
 


### PR DESCRIPTION
- [x] basic install
- [x] running test
- [ ] configuring editors to lint

EDIT: More info:

This pull request adds a basic developer's documentation for configuring workspace appropriately for dev. I know documentation exists elsewhere (many of the scripts seem generated through WP-CLI), but it took me, an experienced PHP dev but WP "Core" novice, a day of dev time to read.

This summary should speed further contribution.