### PR TITLE
Disable HHVM to "fix" HHVM Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 sudo: false
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: php
 
-dist: trusty
-
 sudo: false
 
 php:
     - 5.3
     - 5.6
     - 7.0
-    - hhvm
+
+matrix:
+  include:
+  - php: hhvm
+    dist: trusty
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ cache:
 # Clones WordPress and configures our testing environment.
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
+  # Travis does not properly configure localhost password, even though `127.0.0.1`
+  # is fine (https://github.com/travis-ci/travis-ci/issues/6961):
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('')"; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
   - bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ php:
     - 5.6
     - 7.0
 
-matrix:
-  include:
-  - php: hhvm
-    dist: trusty
+# matrix:
+#   include:
+#   - php: hhvm
+#     dist: trusty
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
@@ -27,9 +27,6 @@ cache:
 # Clones WordPress and configures our testing environment.
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
-  # Travis does not properly configure localhost password, even though `127.0.0.1`
-  # is fine (https://github.com/travis-ci/travis-ci/issues/6961):
-  - if [[ $TRAVIS_PHP_VERSION == 'hhvm' ]]; then mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('')"; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
   - bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
     - 5.6
     - 7.0
 
+# Disable HHVM until we can move to trusty without errors:
+# https://github.com/travis-ci/travis-ci/issues/6842
 # matrix:
 #   include:
 #   - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ php:
 
 # Disable HHVM until we can move to trusty without errors:
 # https://github.com/travis-ci/travis-ci/issues/6842
-# matrix:
-#   include:
-#   - php: hhvm
-#     dist: trusty
+matrix:
+  include:
+  - php: hhvm
+    dist: trusty
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
@@ -31,6 +31,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
+  - which mysql && until mysql -u root -e "show status" &>/dev/null; do sleep 1; echo 'Waiting for MySQL...'; done
   - bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
   # Travis does not properly configure localhost password, even though `127.0.0.1`
   # is fine (https://github.com/travis-ci/travis-ci/issues/6961):
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('')"; fi
+  - if [[ $TRAVIS_PHP_VERSION == 'hhvm' ]]; then mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('')"; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
   - bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
 env:
     - WP_VERSION=latest WP_MULTISITE=0
 
+services:
+  - mysql
+
 ## Cache composer bits
 cache:
   directories:


### PR DESCRIPTION
See [https://github.com/travis-ci/travis-ci/issues/7712](https://github.com/travis-ci/travis-ci/issues/7712)

EDIT: more info:

HHVM build (for HHVM 3.9+ I believe) requires Ubuntu Trusty on Travis, which is a notorious bug system.

# Steps to reproduce:

1. Make pull request. Travis CI will fail for HHVM build no matter what.

# Expected result:

1. Modifications of, say, documentation, should not break build.