### PR TITLE
Package the plugin for developer use

### DIFF
--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Class WP_Test_Fields_Plugin_Instantiation
+ *
+ * @uses PHPUnit_Framework_TestCase
+ */
+class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
+
+
+}

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -57,6 +57,7 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 
 	public function test_can_multiple_include_file() {
 		include __DIR__ . "/../wordpress-fields-api.php";
+		$this->assertTrue( true ); // Pass this test if include was successful.
 	}
 
 	// test disabling builtin form override

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -8,14 +8,32 @@
 class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 
 	// test that WP recognizes this as a plugin
-	public function test_is_wp_plugin() {}
+	public function test_is_wp_plugin() {
+		// TODO: if registered as a plugin, ensure class loads.
+		// This is the default behavior of `bootstrap.php`
+	}
 
 	// test that I can include it myself
-	public function test_is_composer_plugin() {}
+	public function test_is_composer_plugin() {
+		// TODO: if registered using composer, ensure class loads
+		// TODO: disable `boostrap.php` behavior for this test
+		// TODO: `require` the class file manually
+	}
 
 	// test that multiple versions (no matter who starts them) defer to newest
-	public function test_defers_to_latest_version() {}
+	public function test_defers_to_latest_version() {
+		// Try including the plugin with differing versions
+		// TODO: detect if included manually or by traditional plugin activation
+		// TODO: don't execute hooks if some sort of testing override is defined
+
+		// Verify that the newest version loads
+		// TODO: execute hook twice, ensure registered version is highest :D
+	}
 
 	// test that warnings appear when multiple versions are installed
-	public function test_warns_about_dependency_hell() {}
+	public function test_warns_about_dependency_hell() {
+		// As before, include multiple versions
+
+		// Verify that some sort of warning is emitted.
+	}
 }

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -42,6 +42,7 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 		_wp_fields_api_include( $HIGH_VERSION );
 
 		// Verify that some sort of warning is emitted.
-		// TODO: is_admin, show message on plugins screen, eg.
+		$this->expectOutputRegex("/A plugin is trying to include an older version\s+\($LOW_VERSION <= $HIGH_VERSION\)\s+of the <strong>WP Fields API<\/strong>./m");
+		do_action( 'admin_notices' );
 	}
 }

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -55,6 +55,10 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 		ob_end_clean();
 	}
 
+	public function test_can_multiple_include_file() {
+		include __DIR__ . "/../wordpress-fields-api.php";
+	}
+
 	// test disabling builtin form override
 	public function test_can_disable_builtin_form_override() {}
 }

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -7,5 +7,15 @@
  */
 class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 
+	// test that WP recognizes this as a plugin
+	public function test_is_wp_plugin() {}
 
+	// test that I can include it myself
+	public function test_is_composer_plugin() {}
+
+	// test that multiple versions (no matter who starts them) defer to newest
+	public function test_defers_to_latest_version() {}
+
+	// test that warnings appear when multiple versions are installed
+	public function test_warns_about_dependency_hell() {}
 }

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -29,20 +29,27 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 
 		// Verify that the newest version loads
 		$this->assertEquals( WP_FIELDS_API_PLUGIN_VERSION, $HIGH_VERSION );
-
-		// TODO: don't execute hooks if some sort of testing override is defined
 	}
 
 	// test that warnings appear when multiple versions are installed
 	public function test_warns_about_dependency_hell() {
 		// As before, include multiple versions
 		$LOW_VERSION = '1.0.0';
+		$MIDDLE_VERSION = '1.5.0';
 		$HIGH_VERSION = '2.0.0';
 		_wp_fields_api_include( $LOW_VERSION );
 		_wp_fields_api_include( $HIGH_VERSION );
+		_wp_fields_api_include( $MIDDLE_VERSION );
 
 		// Verify that some sort of warning is emitted.
-		$this->expectOutputRegex("/A plugin is trying to include an older version\s+\($LOW_VERSION <= $HIGH_VERSION\)\s+of the <strong>WP Fields API<\/strong>./m");
+		ob_start();
 		do_action( 'admin_notices' );
+		$output = ob_get_contents();
+		$this->assertRegExp("/A plugin is trying to include an older version\s+\($LOW_VERSION <= $HIGH_VERSION\)\s+of the <strong>WP Fields API<\/strong>./m", $output);
+		$this->assertRegExp("/A plugin is trying to include an older version\s+\($MIDDLE_VERSION <= $HIGH_VERSION\)\s+of the <strong>WP Fields API<\/strong>./m", $output);
+		ob_end_clean();
 	}
+
+	// test disabling builtin form override
+	public function test_can_disable_builtin_form_override() {}
 }

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -24,8 +24,9 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 		// Try including the plugin with differing versions
 		$LOW_VERSION = '1.0.0';
 		$HIGH_VERSION = '2.0.0';
-		_wp_fields_api_include( $LOW_VERSION );
-		_wp_fields_api_include( $HIGH_VERSION );
+		WP_Fields_API_v_0_1_0::_debug_force_initialize( $LOW_VERSION );
+		WP_Fields_API_v_0_1_0::_debug_force_initialize( $HIGH_VERSION );
+		do_action( 'plugins_loaded' );
 
 		// Verify that the newest version loads
 		$this->assertEquals( WP_FIELDS_API_PLUGIN_VERSION, $HIGH_VERSION );

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -7,23 +7,29 @@
  */
 class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 
-	// test that WP recognizes this as a plugin
-	public function test_is_wp_plugin() {
-		// TODO: if registered as a plugin, ensure class loads.
-		// This is the default behavior of `bootstrap.php`
-	}
+	// TODO deal with https://make.wordpress.org/plugins/2016/03/01/please-do-not-submit-frameworks/
 
-	// test that I can include it myself
-	public function test_is_composer_plugin() {
-		// TODO: if registered using composer, ensure class loads
-		// TODO: disable `boostrap.php` behavior for this test
-		// TODO: `require` the class file manually
+	// print_r(get_class_methods($this));
+	// die;
+
+	// Make sure that when the plugin loads (via `plugins_loaded`) it starts 
+	// with the correct version number.
+	public function test_begins_with_currect_version() {
+		$VERSION = "0.1.0";
+		$this->assertEquals(WP_FIELDS_API_PLUGIN_VERSION, $VERSION);
 	}
 
 	// test that multiple versions (no matter who starts them) defer to newest
 	public function test_defers_to_latest_version() {
 		// Try including the plugin with differing versions
-		// TODO: detect if included manually or by traditional plugin activation
+		$LOW_VERSION = "1.0.0";
+		$HIGH_VERSION = "2.0.0";
+		_wp_fields_api_include( $LOW_VERSION );
+		_wp_fields_api_include( $HIGH_VERSION );
+
+		$this->assertEquals(WP_FIELDS_API_PLUGIN_VERSION, $HIGH_VERSION);
+
+
 		// TODO: don't execute hooks if some sort of testing override is defined
 
 		// Verify that the newest version loads

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -15,31 +15,33 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 	// Make sure that when the plugin loads (via `plugins_loaded`) it starts 
 	// with the correct version number.
 	public function test_begins_with_currect_version() {
-		$VERSION = "0.1.0";
-		$this->assertEquals(WP_FIELDS_API_PLUGIN_VERSION, $VERSION);
+		$VERSION = '0.1.0';
+		$this->assertEquals( WP_FIELDS_API_PLUGIN_VERSION, $VERSION );
 	}
 
 	// test that multiple versions (no matter who starts them) defer to newest
 	public function test_defers_to_latest_version() {
 		// Try including the plugin with differing versions
-		$LOW_VERSION = "1.0.0";
-		$HIGH_VERSION = "2.0.0";
+		$LOW_VERSION = '1.0.0';
+		$HIGH_VERSION = '2.0.0';
 		_wp_fields_api_include( $LOW_VERSION );
 		_wp_fields_api_include( $HIGH_VERSION );
 
-		$this->assertEquals(WP_FIELDS_API_PLUGIN_VERSION, $HIGH_VERSION);
-
+		// Verify that the newest version loads
+		$this->assertEquals( WP_FIELDS_API_PLUGIN_VERSION, $HIGH_VERSION );
 
 		// TODO: don't execute hooks if some sort of testing override is defined
-
-		// Verify that the newest version loads
-		// TODO: execute hook twice, ensure registered version is highest :D
 	}
 
 	// test that warnings appear when multiple versions are installed
 	public function test_warns_about_dependency_hell() {
 		// As before, include multiple versions
+		$LOW_VERSION = '1.0.0';
+		$HIGH_VERSION = '2.0.0';
+		_wp_fields_api_include( $LOW_VERSION );
+		_wp_fields_api_include( $HIGH_VERSION );
 
 		// Verify that some sort of warning is emitted.
+		// TODO: is_admin, show message on plugins screen, eg.
 	}
 }

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -29,7 +29,7 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 		do_action( 'plugins_loaded' );
 
 		// Verify that the newest version loads
-		$this->assertEquals( WP_FIELDS_API_PLUGIN_VERSION, $HIGH_VERSION );
+		$this->assertEquals( WP_FIELDS_API_PLUGIN_VERSION, $HIGH_VERSION);
 	}
 
 	// test that warnings appear when multiple versions are installed

--- a/tests/test-plugin-instantiation.php
+++ b/tests/test-plugin-instantiation.php
@@ -37,12 +37,16 @@ class WP_Test_Fields_Plugin_Instantiation extends WP_UnitTestCase {
 		$LOW_VERSION = '1.0.0';
 		$MIDDLE_VERSION = '1.5.0';
 		$HIGH_VERSION = '2.0.0';
-		_wp_fields_api_include( $LOW_VERSION );
-		_wp_fields_api_include( $HIGH_VERSION );
-		_wp_fields_api_include( $MIDDLE_VERSION );
+		// _wp_fields_api_include( $LOW_VERSION );
+		// _wp_fields_api_include( $HIGH_VERSION );
+		// _wp_fields_api_include( $MIDDLE_VERSION );
+		WP_Fields_API_v_0_1_0::_debug_force_initialize( $LOW_VERSION, 9999 );
+		WP_Fields_API_v_0_1_0::_debug_force_initialize( $HIGH_VERSION, 9997 );
+		WP_Fields_API_v_0_1_0::_debug_force_initialize( $MIDDLE_VERSION, 9998 );
 
 		// Verify that some sort of warning is emitted.
 		ob_start();
+		do_action( 'plugins_loaded' );
 		do_action( 'admin_notices' );
 		$output = ob_get_contents();
 		$this->assertRegExp("/A plugin is trying to include an older version\s+\($LOW_VERSION <= $HIGH_VERSION\)\s+of the <strong>WP Fields API<\/strong>./m", $output);

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -87,7 +87,7 @@ class WP_Fields_API_v_0_1_0 {
 		 add_action( 'plugins_loaded', array( $this, 'include_wp_customizer' ), 9 ); */
 
 		// @todo make this optional!
- 		add_action( 'fields_register', array( $this, 'include_default_forms' ), 5 );
+		add_action( 'fields_register', array( $this, 'include_default_forms' ), 5 );
 
 		// Post
 		add_action( 'load-post.php', array( $this, 'override_page' ), 999 );
@@ -149,7 +149,7 @@ class WP_Fields_API_v_0_1_0 {
 	}
 
 	/**
-	 * Echo a warning on admin pages if multiple copies of this plugin 
+	 * Echo a warning on admin pages if multiple copies of this plugin
 	 * are installed.
 	 * @todo modify this warning if WP Fields is part of core :)
 	 * @return void
@@ -227,9 +227,6 @@ class WP_Fields_API_v_0_1_0 {
 			'type' => 'comment-edit',
 			'object_subtype' => 'comment-edit',
 		) );
-
-
-
 	}
 
 	/**

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -58,13 +58,19 @@ if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
 			$this->version = $version;
 			$this->priority = $priority;
 
-			add_action( 'plugins_loaded', array( $this, 'attempt_include' ), $this->priority );
+			add_action( 'plugins_loaded', array( $this, 'attempt_include_core_manager' ), $this->priority );
+
+			// Uncomment if you would like to replace the WP Customizer with
+			// our in-home replacement:
+			/* remove_action( 'plugins_loaded', '_wp_customize_include' );
+			 add_action( 'plugins_loaded', array( $this, 'include_wp_customizer' ), 9 ); */
+
 		}
 
 		/**
 		 * On `plugins_loaded`, create an instance of the Fields API manager class.
 		 */
-		public function attempt_include() {
+		public function attempt_include_core_manager() {
 
 			// Bail if we're already in WP core (depending on the name used)
 			// or if a newer version exists
@@ -110,28 +116,25 @@ if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
 			</div>
 			<?php
 		}
+
+		/**
+		 * Implement Fields API Customizer instead of WP Core Customizer.
+		 */
+		public function include_wp_customizer() {
+
+			if ( ! ( ( isset( $_REQUEST['wp_customize'] ) && 'on' == $_REQUEST['wp_customize'] ) || ( is_admin() && 'customize.php' == basename( $_SERVER['PHP_SELF'] ) ) ) ) {
+				return;
+			}
+
+			require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/class-wp-customize-manager.php' );
+
+			// Init Customize class
+			$GLOBALS['wp_customize'] = new WP_Customize_Manager;
+
+		}
 	}
 
 	WP_Fields_API_v_0_1_0::initialize();
-
-	/**
-	 * Implement Fields API Customizer instead of WP Core Customizer.
-	 */
-	function _wp_fields_api_customize_include() {
-
-		if ( ! ( ( isset( $_REQUEST['wp_customize'] ) && 'on' == $_REQUEST['wp_customize'] ) || ( is_admin() && 'customize.php' == basename( $_SERVER['PHP_SELF'] ) ) ) ) {
-			return;
-		}
-
-		require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/class-wp-customize-manager.php' );
-
-		// Init Customize class
-		$GLOBALS['wp_customize'] = new WP_Customize_Manager;
-
-	}
-
-	/*remove_action( 'plugins_loaded', '_wp_customize_include' );
-	add_action( 'plugins_loaded', '_wp_fields_api_customize_include', 9 );*/
 
 	/**
 	 * Include Implementations

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -24,18 +24,29 @@ if ( defined( 'WP_FIELDS_API_TESTING' ) && WP_FIELDS_API_TESTING && ! empty( $_G
  * @codeCoverageIgnore
  */
 
-// Don't bother redeclaring our WP_Fields_API class if one exists.
-// We need to do a null check on the singleton instance since PHP hoists
-// classes, so `class_exists()` returns `true` here.
+// Don't bother redeclaring this version of the WP_Fields_API class if one
+// exists. We need to do a null check on the singleton instance since PHP
+// hoists classes, so `class_exists()` returns `true` here.
 if( null !== WP_Fields_API_v_0_1_0::$instance ) {
 	return;
 }
 
 class WP_Fields_API_v_0_1_0 {
+	// @todo we do nothing with `VERSION` at the moment, but it would be nice
+	// if we could have WP autoload only the most recent version. For now
+	// it's `PRIORITY` that does all the work.
 	const VERSION = '0.1.0';
+	// @todo ensure formal system for `PRIORITY` decrement or have `VERSION`-
+	// based loading.
 	const PRIORITY = 9999;
 
 	public static $instance = null;
+	/**
+	 * Initialize this plugin! This is the primary entry point: load the
+	 * stuff you need, set up the hooks you want. Prevents double-inclusion,
+	 * too.
+	 * @return self the instance of this class. Not really useful to most.
+	 */
 	public static function initialize() {
 		if( null === self::$instance ) {
 			self::$instance = new self();
@@ -44,8 +55,17 @@ class WP_Fields_API_v_0_1_0 {
 		return self::$instance;
 	}
 
-	// Force creation of this class (effectively try to load this class again)
-	// for debug (specifically for testing version handling)
+	/**
+	 * Force creation of this class (effectively try to load this class again)
+	 * for debug (specifically for testing version handling).
+	 * 
+	 * You should never have to call this function. It's behavior is only
+	 * defined (and useful) for testing to make sure double-inclusion *can't*
+	 * occur.
+	 * @param string $version `version_compare`-compatible version string
+	 * @param int $priority inclusion priority. Lower is earlier.
+	 * @return self the necromanced version of this class.
+	 */
 	public static function _debug_force_initialize( $version = self::VERSION, $priority = self::PRIORITY ) {
 		return new self( $version, $priority );
 	}

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -24,251 +24,254 @@ if ( defined( 'WP_FIELDS_API_TESTING' ) && WP_FIELDS_API_TESTING && ! empty( $_G
  * @codeCoverageIgnore
  */
 
-/**
- * The absolute server path to the fields API directory.
- */
-define( 'WP_FIELDS_API_DIR', plugin_dir_path( __FILE__ ) );
-define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
+// @todo switch to positive detection; requires all functions to be encapsulated.
+if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
+	/**
+	 * The absolute server path to the fields API directory.
+	 */
+	define( 'WP_FIELDS_API_DIR', plugin_dir_path( __FILE__ ) );
+	define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
 
-class WP_Fields_API_v_0_1_0 {
-	const VERSION = '0.1.0';
-	const PRIORITY = 9999;
+	class WP_Fields_API_v_0_1_0 {
+		const VERSION = '0.1.0';
+		const PRIORITY = 9999;
 
-	public static $instance = null;
-	public static function initialize() {
-		if( null === self::$instance ) {
-			self::$instance = new self();
+		public static $instance = null;
+		public static function initialize() {
+			if( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
 		}
 
-		return self::$instance;
+		// Force creation of this class (effectively try to load this class again)
+		// for debug (specifically for testing version handling)
+		public static function _debug_force_initialize( $version = self::VERSION, $priority = self::PRIORITY ) {
+			return new self( $version, $priority );
+		}
+
+		public $version = '';
+		public $priority = '';
+
+		private function __construct( $version = self::VERSION, $priority = self::PRIORITY ) {
+			$this->version = $version;
+			$this->priority = $priority;
+
+			add_action( 'plugins_loaded', array( $this, 'attempt_include' ), $this->priority );
+		}
+
+		/**
+		 * On `plugins_loaded`, create an instance of the Fields API manager class.
+		 */
+		public function attempt_include() {
+
+			// Bail if we're already in WP core (depending on the name used)
+			// or if a newer version exists
+			// TODO: modify this warning if the API is part of core
+			if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
+				add_action( 'admin_notices', array( $this, 'warn_about_multiple_copies' ) );
+
+				return;
+			}
+
+			// This version number is used in warnings created by older versions
+			// (if any exist).
+			define( 'WP_FIELDS_API_PLUGIN_VERSION', $this->version );
+
+			require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/class-wp-fields-api.php' );
+
+			// Init Fields API class
+			$GLOBALS['wp_fields'] = WP_Fields_API::get_instance();
+
+			if ( defined( 'WP_FIELDS_API_EXAMPLES' ) && WP_FIELDS_API_EXAMPLES ) {
+				include_once( WP_FIELDS_API_DIR . 'docs/examples/option/_starter.php' );
+				include_once( WP_FIELDS_API_DIR . 'docs/examples/term/_starter.php' );
+				include_once( WP_FIELDS_API_DIR . 'docs/examples/user/_starter.php' );
+				include_once( WP_FIELDS_API_DIR . 'docs/examples/user/address.php' );
+			}
+
+		}
+
+		public function warn_about_multiple_copies() {
+			?>
+			<div class="notice notice-warning">
+				<p>
+					A plugin is trying to include an older version
+					(<?php echo $this->version; ?> <= <?php echo WP_FIELDS_API_PLUGIN_VERSION; ?>)
+					of the <strong>WP Fields API</strong>.
+				</p>
+				<p>
+					This might not cause problems, but
+					you should contact the plugin author and ask
+					them to update their plugin (trying to load the Fields API from
+					<code><?php echo __FILE__; ?></code>).
+				</p>
+			</div>
+			<?php
+		}
 	}
 
-	// Force creation of this class (effectively try to load this class again)
-	// for debug (specifically for testing version handling)
-	public static function _debug_force_initialize( $version = self::VERSION, $priority = self::PRIORITY ) {
-		return new self( $version, $priority );
-	}
-
-	public $version = '';
-	public $priority = '';
-
-	private function __construct( $version = self::VERSION, $priority = self::PRIORITY ) {
-		$this->version = $version;
-		$this->priority = $priority;
-
-		add_action( 'plugins_loaded', array( $this, 'attempt_include' ), $this->priority );
-	}
+	WP_Fields_API_v_0_1_0::initialize();
 
 	/**
-	 * On `plugins_loaded`, create an instance of the Fields API manager class.
+	 * Implement Fields API Customizer instead of WP Core Customizer.
 	 */
-	public function attempt_include() {
+	function _wp_fields_api_customize_include() {
 
-		// Bail if we're already in WP core (depending on the name used)
-		// or if a newer version exists
-		// TODO: modify this warning if the API is part of core
-		if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
-			add_action( 'admin_notices', array( $this, 'warn_about_multiple_copies' ) );
-
+		if ( ! ( ( isset( $_REQUEST['wp_customize'] ) && 'on' == $_REQUEST['wp_customize'] ) || ( is_admin() && 'customize.php' == basename( $_SERVER['PHP_SELF'] ) ) ) ) {
 			return;
 		}
 
-		// This version number is used in warnings created by older versions
-		// (if any exist).
-		define( 'WP_FIELDS_API_PLUGIN_VERSION', $this->version );
+		require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/class-wp-customize-manager.php' );
 
-		require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/class-wp-fields-api.php' );
+		// Init Customize class
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager;
 
-		// Init Fields API class
-		$GLOBALS['wp_fields'] = WP_Fields_API::get_instance();
+	}
 
-		if ( defined( 'WP_FIELDS_API_EXAMPLES' ) && WP_FIELDS_API_EXAMPLES ) {
-			include_once( WP_FIELDS_API_DIR . 'docs/examples/option/_starter.php' );
-			include_once( WP_FIELDS_API_DIR . 'docs/examples/term/_starter.php' );
-			include_once( WP_FIELDS_API_DIR . 'docs/examples/user/_starter.php' );
-			include_once( WP_FIELDS_API_DIR . 'docs/examples/user/address.php' );
+	/*remove_action( 'plugins_loaded', '_wp_customize_include' );
+	add_action( 'plugins_loaded', '_wp_fields_api_customize_include', 9 );*/
+
+	/**
+	 * Include Implementations
+	 */
+	function _wp_fields_api_implementations() {
+		global $wp_fields;
+
+		$implementation_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/forms/';
+
+		// Meta boxes
+		add_action( 'add_meta_boxes', array( 'WP_Fields_API_Meta_Box_Section', 'add_meta_boxes' ), 10, 2 );
+
+		// Post
+		require_once( $implementation_dir . 'class-wp-fields-api-form-post.php' );
+
+		$wp_fields->register_form_type( 'post-edit', 'WP_Fields_API_Form_Post' );
+		$wp_fields->add_form( 'post', 'post-edit', array(
+			'type' => 'post-edit',
+			'object_subtype' => 'post-edit',
+		) );
+
+		// Term
+		require_once( $implementation_dir . 'class-wp-fields-api-form-term.php' );
+		require_once( $implementation_dir . 'class-wp-fields-api-form-term-add.php' );
+
+		$wp_fields->register_form_type( 'term-edit', 'WP_Fields_API_Form_Term' );
+		$wp_fields->register_form_type( 'term-add', 'WP_Fields_API_Form_Term_Add' );
+
+		$wp_fields->add_form( 'term', 'term-edit', array(
+			'type' => 'term-edit',
+			'object_subtype' => 'term-edit',
+		) );
+
+		$wp_fields->add_form( 'term', 'term-add', array(
+			'type' => 'term-add',
+			'object_subtype' => 'term-add',
+		) );
+
+		// User
+		require_once( $implementation_dir . 'class-wp-fields-api-form-user-edit.php' );
+
+		$wp_fields->register_form_type( 'user-edit', 'WP_Fields_API_Form_User_Edit' );
+		$wp_fields->add_form( 'user', 'user-edit', array(
+			'type' => 'user-edit',
+			'object_subtype' => 'user-edit',
+		) );
+
+		// Comment
+		require_once( $implementation_dir . 'class-wp-fields-api-form-comment.php' );
+
+		$wp_fields->register_form_type( 'comment-edit', 'WP_Fields_API_Form_Comment' );
+		$wp_fields->add_form( 'comment', 'comment-edit', array(
+			'type' => 'comment-edit',
+			'object_subtype' => 'comment-edit',
+		) );
+
+
+
+	}
+	add_action( 'fields_register', '_wp_fields_api_implementations', 5 );
+
+	// Post
+	add_action( 'load-post.php', '_wp_fields_api_load_include', 999 );
+
+	// Term
+	add_action( 'load-edit-tags.php', '_wp_fields_api_load_include', 999 );
+
+	// User
+	add_action( 'load-user-edit.php', '_wp_fields_api_load_include', 999 );
+	add_action( 'load-profile.php', '_wp_fields_api_load_include', 999 );
+
+	// Comment
+	add_action( 'load-comment.php', '_wp_fields_api_load_include', 999 );
+
+	// Settings
+	add_action( 'load-options-general.php', '_wp_fields_api_load_include', 999 );
+	add_action( 'load-options-writing.php', '_wp_fields_api_load_include', 999 );
+	add_action( 'load-options-reading.php', '_wp_fields_api_load_include', 999 );
+	add_action( 'load-options-permalink.php', '_wp_fields_api_load_include', 999 );
+
+	function _wp_fields_api_load_include() {
+
+		global $pagenow;
+
+		static $overridden;
+
+		if ( empty( $overridden ) ) {
+			$overridden = array();
+		}
+
+		$load_path = WP_FIELDS_API_DIR . 'implementation/wp-admin/';
+
+		if ( file_exists( $load_path . $pagenow ) && ! in_array( $pagenow, $overridden ) ) {
+			$overridden[] = $pagenow;
+
+			_wp_fields_api_override_compatibility();
+
+			// Load our override
+			require_once( $load_path . $pagenow );
+
+			// Bail on original core file, don't run the rest
+			exit;
 		}
 
 	}
 
-	public function warn_about_multiple_copies() {
-		?>
-		<div class="notice notice-warning">
-			<p>
-				A plugin is trying to include an older version
-				(<?php echo $this->version; ?> <= <?php echo WP_FIELDS_API_PLUGIN_VERSION; ?>)
-				of the <strong>WP Fields API</strong>.
-			</p>
-			<p>
-				This might not cause problems, but
-				you should contact the plugin author and ask
-				them to update their plugin (trying to load the Fields API from
-				<code><?php echo __FILE__; ?></code>).
-			</p>
-		</div>
-		<?php
-	}
-}
-
-WP_Fields_API_v_0_1_0::initialize();
-
-/**
- * Implement Fields API Customizer instead of WP Core Customizer.
- */
-function _wp_fields_api_customize_include() {
-
-	if ( ! ( ( isset( $_REQUEST['wp_customize'] ) && 'on' == $_REQUEST['wp_customize'] ) || ( is_admin() && 'customize.php' == basename( $_SERVER['PHP_SELF'] ) ) ) ) {
-		return;
-	}
-
-	require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/class-wp-customize-manager.php' );
-
-	// Init Customize class
-	$GLOBALS['wp_customize'] = new WP_Customize_Manager;
-
-}
-
-/*remove_action( 'plugins_loaded', '_wp_customize_include' );
-add_action( 'plugins_loaded', '_wp_fields_api_customize_include', 9 );*/
-
-/**
- * Include Implementations
- */
-function _wp_fields_api_implementations() {
-	global $wp_fields;
-
-	$implementation_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/forms/';
-
-	// Meta boxes
-	add_action( 'add_meta_boxes', array( 'WP_Fields_API_Meta_Box_Section', 'add_meta_boxes' ), 10, 2 );
-
-	// Post
-	require_once( $implementation_dir . 'class-wp-fields-api-form-post.php' );
-
-	$wp_fields->register_form_type( 'post-edit', 'WP_Fields_API_Form_Post' );
-	$wp_fields->add_form( 'post', 'post-edit', array(
-		'type' => 'post-edit',
-		'object_subtype' => 'post-edit',
-	) );
-
-	// Term
-	require_once( $implementation_dir . 'class-wp-fields-api-form-term.php' );
-	require_once( $implementation_dir . 'class-wp-fields-api-form-term-add.php' );
-
-	$wp_fields->register_form_type( 'term-edit', 'WP_Fields_API_Form_Term' );
-	$wp_fields->register_form_type( 'term-add', 'WP_Fields_API_Form_Term_Add' );
-
-	$wp_fields->add_form( 'term', 'term-edit', array(
-		'type' => 'term-edit',
-		'object_subtype' => 'term-edit',
-	) );
-
-	$wp_fields->add_form( 'term', 'term-add', array(
-		'type' => 'term-add',
-		'object_subtype' => 'term-add',
-	) );
-
-	// User
-	require_once( $implementation_dir . 'class-wp-fields-api-form-user-edit.php' );
-
-	$wp_fields->register_form_type( 'user-edit', 'WP_Fields_API_Form_User_Edit' );
-	$wp_fields->add_form( 'user', 'user-edit', array(
-		'type' => 'user-edit',
-		'object_subtype' => 'user-edit',
-	) );
-
-	// Comment
-	require_once( $implementation_dir . 'class-wp-fields-api-form-comment.php' );
-
-	$wp_fields->register_form_type( 'comment-edit', 'WP_Fields_API_Form_Comment' );
-	$wp_fields->add_form( 'comment', 'comment-edit', array(
-		'type' => 'comment-edit',
-		'object_subtype' => 'comment-edit',
-	) );
-
-
-
-}
-add_action( 'fields_register', '_wp_fields_api_implementations', 5 );
-
-// Post
-add_action( 'load-post.php', '_wp_fields_api_load_include', 999 );
-
-// Term
-add_action( 'load-edit-tags.php', '_wp_fields_api_load_include', 999 );
-
-// User
-add_action( 'load-user-edit.php', '_wp_fields_api_load_include', 999 );
-add_action( 'load-profile.php', '_wp_fields_api_load_include', 999 );
-
-// Comment
-add_action( 'load-comment.php', '_wp_fields_api_load_include', 999 );
-
-// Settings
-add_action( 'load-options-general.php', '_wp_fields_api_load_include', 999 );
-add_action( 'load-options-writing.php', '_wp_fields_api_load_include', 999 );
-add_action( 'load-options-reading.php', '_wp_fields_api_load_include', 999 );
-add_action( 'load-options-permalink.php', '_wp_fields_api_load_include', 999 );
-
-function _wp_fields_api_load_include() {
-
-	global $pagenow;
-
-	static $overridden;
-
-	if ( empty( $overridden ) ) {
-		$overridden = array();
-	}
-
-	$load_path = WP_FIELDS_API_DIR . 'implementation/wp-admin/';
-
-	if ( file_exists( $load_path . $pagenow ) && ! in_array( $pagenow, $overridden ) ) {
-		$overridden[] = $pagenow;
-
-		_wp_fields_api_override_compatibility();
-
-		// Load our override
-		require_once( $load_path . $pagenow );
-
-		// Bail on original core file, don't run the rest
-		exit;
-	}
-
-}
-
-/**
- * Used to maintain compatibiltiy on all overrides
- */
-function _wp_fields_api_override_compatibility() {
-
-	global $typenow, $pagenow, $taxnow;
-
-	/*
-	 * The following hooks are fired to ensure backward compatibility.
-	 * In all other cases, 'load-' . $pagenow should be used instead.
+	/**
+	 * Used to maintain compatibiltiy on all overrides
 	 */
-	if ( $typenow == 'page' ) {
-		if ( $pagenow == 'post-new.php' )
-			do_action( 'load-page-new.php' );
-		elseif ( $pagenow == 'post.php' )
-			do_action( 'load-page.php' );
-	}  elseif ( $pagenow == 'edit-tags.php' ) {
-		if ( $taxnow == 'category' )
-			do_action( 'load-categories.php' );
-		elseif ( $taxnow == 'link_category' )
-			do_action( 'load-edit-link-categories.php' );
-	}
+	function _wp_fields_api_override_compatibility() {
 
-	if ( ! empty( $_REQUEST['action'] ) ) {
-		/**
-		 * Fires when an 'action' request variable is sent.
-		 *
-		 * The dynamic portion of the hook name, `$_REQUEST['action']`,
-		 * refers to the action derived from the `GET` or `POST` request.
-		 *
-		 * @since 2.6.0
+		global $typenow, $pagenow, $taxnow;
+
+		/*
+		 * The following hooks are fired to ensure backward compatibility.
+		 * In all other cases, 'load-' . $pagenow should be used instead.
 		 */
-		do_action( 'admin_action_' . $_REQUEST['action'] );
-	}
+		if ( $typenow == 'page' ) {
+			if ( $pagenow == 'post-new.php' )
+				do_action( 'load-page-new.php' );
+			elseif ( $pagenow == 'post.php' )
+				do_action( 'load-page.php' );
+		}  elseif ( $pagenow == 'edit-tags.php' ) {
+			if ( $taxnow == 'category' )
+				do_action( 'load-categories.php' );
+			elseif ( $taxnow == 'link_category' )
+				do_action( 'load-edit-link-categories.php' );
+		}
 
+		if ( ! empty( $_REQUEST['action'] ) ) {
+			/**
+			 * Fires when an 'action' request variable is sent.
+			 *
+			 * The dynamic portion of the hook name, `$_REQUEST['action']`,
+			 * refers to the action derived from the `GET` or `POST` request.
+			 *
+			 * @since 2.6.0
+			 */
+			do_action( 'admin_action_' . $_REQUEST['action'] );
+		}
+
+	}
 }

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -30,6 +30,59 @@ if ( defined( 'WP_FIELDS_API_TESTING' ) && WP_FIELDS_API_TESTING && ! empty( $_G
 define( 'WP_FIELDS_API_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
 
+class WP_Fields_API_v_0_1_0 {
+	const VERSION = '0.1.0';
+	const PRIORITY = 9999;
+
+	public static $instance = null;
+	public static function initialize() {
+		if( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	// Force creation of this class (effectively try to load this class again)
+	// for debug (specifically for testing version handling)
+	public static function _debug_force_initialize( $version = self::VERSION, $priority = self::PRIORITY ) {
+		return new self( $version, $priority );
+	}
+
+	public $version = '';
+	public $priority = '';
+
+	private function __construct( $version = self::VERSION, $priority = self::PRIORITY ) {
+		$this->version = $version;
+		$this->priority = $priority;
+
+		add_action( 'plugins_loaded', array( $this, 'attempt_include' ), $this->priority );
+	}
+
+	public function attempt_include() {
+		if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
+			add_action( 'admin_notices', array( $this, 'warn_about_multiple_copies' ) );
+		}
+	}
+
+	public function warn_about_multiple_copies() {
+		?>
+		<div class="notice notice-warning">
+			<p>
+				A plugin is trying to include an older version
+				(<?php echo $this->version; ?> <= <?php echo WP_FIELDS_API_PLUGIN_VERSION; ?>)
+				of the <strong>WP Fields API</strong>.
+			</p>
+			<p>
+				This might not cause problems, but
+				you should contact the plugin author and ask
+				them to update their plugin (trying to load the Fields API from
+				<code><?php echo __FILE__; ?></code>).
+			</p>
+		</div>
+		<?php
+	}
+}
 
 function _wp_fields_api_warn_multiple_copies() {
 	$version = '0.1.0';

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -65,13 +65,16 @@ class WP_Fields_API_v_0_1_0 {
 	public function attempt_include() {
 
 		// Bail if we're already in WP core (depending on the name used)
+		// or if a newer version exists
+		// TODO: modify this warning if the API is part of core
 		if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
 			add_action( 'admin_notices', array( $this, 'warn_about_multiple_copies' ) );
 
 			return;
 		}
 
-		// Set version number
+		// This version number is used in warnings created by older versions
+		// (if any exist).
 		define( 'WP_FIELDS_API_PLUGIN_VERSION', $this->version );
 
 		require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/class-wp-fields-api.php' );

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -24,268 +24,272 @@ if ( defined( 'WP_FIELDS_API_TESTING' ) && WP_FIELDS_API_TESTING && ! empty( $_G
  * @codeCoverageIgnore
  */
 
-// @todo switch to positive detection; requires all functions to be encapsulated.
-if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
-	/**
-	 * The absolute server path to the fields API directory.
-	 */
-	define( 'WP_FIELDS_API_DIR', plugin_dir_path( __FILE__ ) );
-	define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
+// Don't bother redeclaring our WP_Fields_API class if one exists.
+// We need to do a null check on the singleton instance since PHP hoists
+// classes, so `class_exists()` returns `true` here.
+if( null !== WP_Fields_API_v_0_1_0::$instance ) {
+	return;
+}
 
-	class WP_Fields_API_v_0_1_0 {
-		const VERSION = '0.1.0';
-		const PRIORITY = 9999;
+class WP_Fields_API_v_0_1_0 {
+	const VERSION = '0.1.0';
+	const PRIORITY = 9999;
 
-		public static $instance = null;
-		public static function initialize() {
-			if( null === self::$instance ) {
-				self::$instance = new self();
-			}
-
-			return self::$instance;
+	public static $instance = null;
+	public static function initialize() {
+		if( null === self::$instance ) {
+			self::$instance = new self();
 		}
 
-		// Force creation of this class (effectively try to load this class again)
-		// for debug (specifically for testing version handling)
-		public static function _debug_force_initialize( $version = self::VERSION, $priority = self::PRIORITY ) {
-			return new self( $version, $priority );
-		}
-
-		public $version = '';
-		public $priority = '';
-
-		private function __construct( $version = self::VERSION, $priority = self::PRIORITY ) {
-			$this->version = $version;
-			$this->priority = $priority;
-
-			// Include our mananager so that you can register fields!
-			// @todo we need to think about how to change priority so that only the newest loads
-			add_action( 'plugins_loaded', array( $this, 'attempt_include_core_manager' ), $this->priority );
-
-			// Uncomment if you would like to replace the WP Customizer with
-			// our in-home replacement:
-			/* remove_action( 'plugins_loaded', '_wp_customize_include' );
-			 add_action( 'plugins_loaded', array( $this, 'include_wp_customizer' ), 9 ); */
-
-			// @todo make this optional!
-	 		add_action( 'fields_register', array( $this, 'include_default_forms' ), 5 );
-
-			// Post
-			add_action( 'load-post.php', array( $this, 'override_page' ), 999 );
-
-			// Term
-			add_action( 'load-edit-tags.php', array( $this, 'override_page' ), 999 );
-
-			// User
-			add_action( 'load-user-edit.php', array( $this, 'override_page' ), 999 );
-			add_action( 'load-profile.php', array( $this, 'override_page' ), 999 );
-
-			// Comment
-			add_action( 'load-comment.php', array( $this, 'override_page' ), 999 );
-
-			// Settings
-			add_action( 'load-options-general.php', array( $this, 'override_page' ), 999 );
-			add_action( 'load-options-writing.php', array( $this, 'override_page' ), 999 );
-			add_action( 'load-options-reading.php', array( $this, 'override_page' ), 999 );
-			add_action( 'load-options-permalink.php', array( $this, 'override_page' ), 999 );
-
-		}
-
-		/**
-		 * On `plugins_loaded`, create an instance of the Fields API manager class.
-		 */
-		public function attempt_include_core_manager() {
-
-			// Bail if we're already in WP core (depending on the name used)
-			// or if a newer version exists
-			// TODO: modify this warning if the API is part of core
-			if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
-				add_action( 'admin_notices', array( $this, 'warn_about_multiple_copies' ) );
-
-				return;
-			}
-
-			// This version number is used in warnings created by older versions
-			// (if any exist).
-			define( 'WP_FIELDS_API_PLUGIN_VERSION', $this->version );
-
-			require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/class-wp-fields-api.php' );
-
-			// Init Fields API class
-			$GLOBALS['wp_fields'] = WP_Fields_API::get_instance();
-
-			if ( defined( 'WP_FIELDS_API_EXAMPLES' ) && WP_FIELDS_API_EXAMPLES ) {
-				include_once( WP_FIELDS_API_DIR . 'docs/examples/option/_starter.php' );
-				include_once( WP_FIELDS_API_DIR . 'docs/examples/term/_starter.php' );
-				include_once( WP_FIELDS_API_DIR . 'docs/examples/user/_starter.php' );
-				include_once( WP_FIELDS_API_DIR . 'docs/examples/user/address.php' );
-			}
-
-		}
-
-		/**
-		 * Echo a warning on admin pages if multiple copies of this plugin 
-		 * are installed.
-		 * @todo modify this warning if WP Fields is part of core :)
-		 * @return void
-		 */
-		public function warn_about_multiple_copies() {
-			?>
-			<div class="notice notice-warning">
-				<p>
-					A plugin is trying to include an older version
-					(<?php echo $this->version; ?> <= <?php echo WP_FIELDS_API_PLUGIN_VERSION; ?>)
-					of the <strong>WP Fields API</strong>.
-				</p>
-				<p>
-					This might not cause problems, but
-					you should contact the plugin author and ask
-					them to update their plugin (trying to load the Fields API from
-					<code><?php echo __FILE__; ?></code>).
-				</p>
-			</div>
-			<?php
-		}
-
-		/**
-		 * Include some basic forms (post edit, etc)
-		 * @todo make this optional!
-		 */
-		public function include_default_forms() {
-			global $wp_fields;
-
-			$implementation_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/forms/';
-
-			// Meta boxes
-			add_action( 'add_meta_boxes', array( 'WP_Fields_API_Meta_Box_Section', 'add_meta_boxes' ), 10, 2 );
-
-			// Post
-			require_once( $implementation_dir . 'class-wp-fields-api-form-post.php' );
-
-			$wp_fields->register_form_type( 'post-edit', 'WP_Fields_API_Form_Post' );
-			$wp_fields->add_form( 'post', 'post-edit', array(
-				'type' => 'post-edit',
-				'object_subtype' => 'post-edit',
-			) );
-
-			// Term
-			require_once( $implementation_dir . 'class-wp-fields-api-form-term.php' );
-			require_once( $implementation_dir . 'class-wp-fields-api-form-term-add.php' );
-
-			$wp_fields->register_form_type( 'term-edit', 'WP_Fields_API_Form_Term' );
-			$wp_fields->register_form_type( 'term-add', 'WP_Fields_API_Form_Term_Add' );
-
-			$wp_fields->add_form( 'term', 'term-edit', array(
-				'type' => 'term-edit',
-				'object_subtype' => 'term-edit',
-			) );
-
-			$wp_fields->add_form( 'term', 'term-add', array(
-				'type' => 'term-add',
-				'object_subtype' => 'term-add',
-			) );
-
-			// User
-			require_once( $implementation_dir . 'class-wp-fields-api-form-user-edit.php' );
-
-			$wp_fields->register_form_type( 'user-edit', 'WP_Fields_API_Form_User_Edit' );
-			$wp_fields->add_form( 'user', 'user-edit', array(
-				'type' => 'user-edit',
-				'object_subtype' => 'user-edit',
-			) );
-
-			// Comment
-			require_once( $implementation_dir . 'class-wp-fields-api-form-comment.php' );
-
-			$wp_fields->register_form_type( 'comment-edit', 'WP_Fields_API_Form_Comment' );
-			$wp_fields->add_form( 'comment', 'comment-edit', array(
-				'type' => 'comment-edit',
-				'object_subtype' => 'comment-edit',
-			) );
-
-
-
-		}
-
-		/**
-		 * Implement Fields API Customizer instead of WP Core Customizer.
-		 */
-		public function include_wp_customizer() {
-
-			if ( ! ( ( isset( $_REQUEST['wp_customize'] ) && 'on' == $_REQUEST['wp_customize'] ) || ( is_admin() && 'customize.php' == basename( $_SERVER['PHP_SELF'] ) ) ) ) {
-				return;
-			}
-
-			require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/class-wp-customize-manager.php' );
-
-			// Init Customize class
-			$GLOBALS['wp_customize'] = new WP_Customize_Manager;
-
-		}
-
-		public function override_page() {
-
-			global $pagenow;
-
-			static $overridden;
-
-			if ( empty( $overridden ) ) {
-				$overridden = array();
-			}
-
-			$load_path = WP_FIELDS_API_DIR . 'implementation/wp-admin/';
-
-			if ( file_exists( $load_path . $pagenow ) && ! in_array( $pagenow, $overridden ) ) {
-				$overridden[] = $pagenow;
-
-				$this->override_compatibility();
-
-				// Load our override
-				require_once( $load_path . $pagenow );
-
-				// Bail on original core file, don't run the rest
-				exit;
-			}
-
-		}
-
-		/**
-		 * Used to maintain compatibiltiy on all overrides
-		 */
-		private function override_compatibility() {
-
-			global $typenow, $pagenow, $taxnow;
-
-			/*
-			 * The following hooks are fired to ensure backward compatibility.
-			 * In all other cases, 'load-' . $pagenow should be used instead.
-			 */
-			if ( $typenow == 'page' ) {
-				if ( $pagenow == 'post-new.php' )
-					do_action( 'load-page-new.php' );
-				elseif ( $pagenow == 'post.php' )
-					do_action( 'load-page.php' );
-			}  elseif ( $pagenow == 'edit-tags.php' ) {
-				if ( $taxnow == 'category' )
-					do_action( 'load-categories.php' );
-				elseif ( $taxnow == 'link_category' )
-					do_action( 'load-edit-link-categories.php' );
-			}
-
-			if ( ! empty( $_REQUEST['action'] ) ) {
-				/**
-				 * Fires when an 'action' request variable is sent.
-				 *
-				 * The dynamic portion of the hook name, `$_REQUEST['action']`,
-				 * refers to the action derived from the `GET` or `POST` request.
-				 *
-				 * @since 2.6.0
-				 */
-				do_action( 'admin_action_' . $_REQUEST['action'] );
-			}
-
-		}
+		return self::$instance;
 	}
 
-	WP_Fields_API_v_0_1_0::initialize();
+	// Force creation of this class (effectively try to load this class again)
+	// for debug (specifically for testing version handling)
+	public static function _debug_force_initialize( $version = self::VERSION, $priority = self::PRIORITY ) {
+		return new self( $version, $priority );
+	}
+
+	public $version = '';
+	public $priority = '';
+
+	private function __construct( $version = self::VERSION, $priority = self::PRIORITY ) {
+		$this->version = $version;
+		$this->priority = $priority;
+
+		// Include our mananager so that you can register fields!
+		// @todo we need to think about how to change priority so that only the newest loads
+		add_action( 'plugins_loaded', array( $this, 'attempt_include_core_manager' ), $this->priority );
+
+		// Uncomment if you would like to replace the WP Customizer with
+		// our in-home replacement:
+		/* remove_action( 'plugins_loaded', '_wp_customize_include' );
+		 add_action( 'plugins_loaded', array( $this, 'include_wp_customizer' ), 9 ); */
+
+		// @todo make this optional!
+ 		add_action( 'fields_register', array( $this, 'include_default_forms' ), 5 );
+
+		// Post
+		add_action( 'load-post.php', array( $this, 'override_page' ), 999 );
+
+		// Term
+		add_action( 'load-edit-tags.php', array( $this, 'override_page' ), 999 );
+
+		// User
+		add_action( 'load-user-edit.php', array( $this, 'override_page' ), 999 );
+		add_action( 'load-profile.php', array( $this, 'override_page' ), 999 );
+
+		// Comment
+		add_action( 'load-comment.php', array( $this, 'override_page' ), 999 );
+
+		// Settings
+		add_action( 'load-options-general.php', array( $this, 'override_page' ), 999 );
+		add_action( 'load-options-writing.php', array( $this, 'override_page' ), 999 );
+		add_action( 'load-options-reading.php', array( $this, 'override_page' ), 999 );
+		add_action( 'load-options-permalink.php', array( $this, 'override_page' ), 999 );
+
+	}
+
+	/**
+	 * On `plugins_loaded`, create an instance of the Fields API manager class.
+	 */
+	public function attempt_include_core_manager() {
+
+		// Bail if we're already in WP core (depending on the name used)
+		// or if a newer version exists
+		// TODO: modify this warning if the API is part of core
+		if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
+			add_action( 'admin_notices', array( $this, 'warn_about_multiple_copies' ) );
+
+			return;
+		}
+
+		// This version number is used in warnings created by older versions
+		// (if any exist).
+		define( 'WP_FIELDS_API_PLUGIN_VERSION', $this->version );
+
+		/**
+		 * The absolute server path to the fields API directory.
+		 */
+		define( 'WP_FIELDS_API_DIR', plugin_dir_path( __FILE__ ) );
+		define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
+
+		require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/class-wp-fields-api.php' );
+
+		// Init Fields API class
+		$GLOBALS['wp_fields'] = WP_Fields_API::get_instance();
+
+		if ( defined( 'WP_FIELDS_API_EXAMPLES' ) && WP_FIELDS_API_EXAMPLES ) {
+			include_once( WP_FIELDS_API_DIR . 'docs/examples/option/_starter.php' );
+			include_once( WP_FIELDS_API_DIR . 'docs/examples/term/_starter.php' );
+			include_once( WP_FIELDS_API_DIR . 'docs/examples/user/_starter.php' );
+			include_once( WP_FIELDS_API_DIR . 'docs/examples/user/address.php' );
+		}
+
+	}
+
+	/**
+	 * Echo a warning on admin pages if multiple copies of this plugin 
+	 * are installed.
+	 * @todo modify this warning if WP Fields is part of core :)
+	 * @return void
+	 */
+	public function warn_about_multiple_copies() {
+		?>
+		<div class="notice notice-warning">
+			<p>
+				A plugin is trying to include an older version
+				(<?php echo $this->version; ?> <= <?php echo WP_FIELDS_API_PLUGIN_VERSION; ?>)
+				of the <strong>WP Fields API</strong>.
+			</p>
+			<p>
+				This might not cause problems, but
+				you should contact the plugin author and ask
+				them to update their plugin (trying to load the Fields API from
+				<code><?php echo __FILE__; ?></code>).
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Include some basic forms (post edit, etc)
+	 * @todo make this optional!
+	 */
+	public function include_default_forms() {
+		global $wp_fields;
+
+		$implementation_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/forms/';
+
+		// Meta boxes
+		add_action( 'add_meta_boxes', array( 'WP_Fields_API_Meta_Box_Section', 'add_meta_boxes' ), 10, 2 );
+
+		// Post
+		require_once( $implementation_dir . 'class-wp-fields-api-form-post.php' );
+
+		$wp_fields->register_form_type( 'post-edit', 'WP_Fields_API_Form_Post' );
+		$wp_fields->add_form( 'post', 'post-edit', array(
+			'type' => 'post-edit',
+			'object_subtype' => 'post-edit',
+		) );
+
+		// Term
+		require_once( $implementation_dir . 'class-wp-fields-api-form-term.php' );
+		require_once( $implementation_dir . 'class-wp-fields-api-form-term-add.php' );
+
+		$wp_fields->register_form_type( 'term-edit', 'WP_Fields_API_Form_Term' );
+		$wp_fields->register_form_type( 'term-add', 'WP_Fields_API_Form_Term_Add' );
+
+		$wp_fields->add_form( 'term', 'term-edit', array(
+			'type' => 'term-edit',
+			'object_subtype' => 'term-edit',
+		) );
+
+		$wp_fields->add_form( 'term', 'term-add', array(
+			'type' => 'term-add',
+			'object_subtype' => 'term-add',
+		) );
+
+		// User
+		require_once( $implementation_dir . 'class-wp-fields-api-form-user-edit.php' );
+
+		$wp_fields->register_form_type( 'user-edit', 'WP_Fields_API_Form_User_Edit' );
+		$wp_fields->add_form( 'user', 'user-edit', array(
+			'type' => 'user-edit',
+			'object_subtype' => 'user-edit',
+		) );
+
+		// Comment
+		require_once( $implementation_dir . 'class-wp-fields-api-form-comment.php' );
+
+		$wp_fields->register_form_type( 'comment-edit', 'WP_Fields_API_Form_Comment' );
+		$wp_fields->add_form( 'comment', 'comment-edit', array(
+			'type' => 'comment-edit',
+			'object_subtype' => 'comment-edit',
+		) );
+
+
+
+	}
+
+	/**
+	 * Implement Fields API Customizer instead of WP Core Customizer.
+	 */
+	public function include_wp_customizer() {
+
+		if ( ! ( ( isset( $_REQUEST['wp_customize'] ) && 'on' == $_REQUEST['wp_customize'] ) || ( is_admin() && 'customize.php' == basename( $_SERVER['PHP_SELF'] ) ) ) ) {
+			return;
+		}
+
+		require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/class-wp-customize-manager.php' );
+
+		// Init Customize class
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager;
+
+	}
+
+	public function override_page() {
+
+		global $pagenow;
+
+		static $overridden;
+
+		if ( empty( $overridden ) ) {
+			$overridden = array();
+		}
+
+		$load_path = WP_FIELDS_API_DIR . 'implementation/wp-admin/';
+
+		if ( file_exists( $load_path . $pagenow ) && ! in_array( $pagenow, $overridden ) ) {
+			$overridden[] = $pagenow;
+
+			$this->override_compatibility();
+
+			// Load our override
+			require_once( $load_path . $pagenow );
+
+			// Bail on original core file, don't run the rest
+			exit;
+		}
+
+	}
+
+	/**
+	 * Used to maintain compatibiltiy on all overrides
+	 */
+	private function override_compatibility() {
+
+		global $typenow, $pagenow, $taxnow;
+
+		/*
+		 * The following hooks are fired to ensure backward compatibility.
+		 * In all other cases, 'load-' . $pagenow should be used instead.
+		 */
+		if ( $typenow == 'page' ) {
+			if ( $pagenow == 'post-new.php' )
+				do_action( 'load-page-new.php' );
+			elseif ( $pagenow == 'post.php' )
+				do_action( 'load-page.php' );
+		}  elseif ( $pagenow == 'edit-tags.php' ) {
+			if ( $taxnow == 'category' )
+				do_action( 'load-categories.php' );
+			elseif ( $taxnow == 'link_category' )
+				do_action( 'load-edit-link-categories.php' );
+		}
+
+		if ( ! empty( $_REQUEST['action'] ) ) {
+			/**
+			 * Fires when an 'action' request variable is sent.
+			 *
+			 * The dynamic portion of the hook name, `$_REQUEST['action']`,
+			 * refers to the action derived from the `GET` or `POST` request.
+			 *
+			 * @since 2.6.0
+			 */
+			do_action( 'admin_action_' . $_REQUEST['action'] );
+		}
+
+	}
 }
+
+WP_Fields_API_v_0_1_0::initialize();

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -66,7 +66,7 @@ class WP_Fields_API_v_0_1_0 {
 
 		// Bail if we're already in WP core (depending on the name used)
 		if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
-			add_action( 'admin_notices', '_wp_fields_api_warn_multiple_copies' );
+			add_action( 'admin_notices', array( $this, 'warn_about_multiple_copies' ) );
 
 			return;
 		}

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -58,6 +58,8 @@ if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
 			$this->version = $version;
 			$this->priority = $priority;
 
+			// Include our mananager so that you can register fields!
+			// @todo we need to think about how to change priority so that only the newest loads
 			add_action( 'plugins_loaded', array( $this, 'attempt_include_core_manager' ), $this->priority );
 
 			// Uncomment if you would like to replace the WP Customizer with

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -33,10 +33,19 @@ define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
 /**
  * On `plugins_loaded`, create an instance of the Fields API manager class.
  */
-function _wp_fields_api_include( $api_version = "0.1.0" ) {
+function _wp_fields_api_include( $api_version = '0.1.0' ) {
 
 	// Bail if we're already in WP core (depending on the name used)
 	if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
+		$included_fields_version = WP_FIELDS_API_PLUGIN_VERSION;
+		$file = plugin_dir_path( __FILE__ );
+		
+		// echo "A plugin is trying to include an older version "
+		// 	. "($api_version <= $included_fields_version) "
+		// 	. "of the WP Fields API. This might not cause problems, but "
+		// 	. "you should contact the plugin ($file) author and ask "
+		// 	. "them to update their plugin";
+
 		return;
 	}
 

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -33,12 +33,15 @@ define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
 /**
  * On `plugins_loaded`, create an instance of the Fields API manager class.
  */
-function _wp_fields_api_include() {
+function _wp_fields_api_include( $api_version = "0.1.0" ) {
 
 	// Bail if we're already in WP core (depending on the name used)
 	if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
 		return;
 	}
+
+	// Set version number
+	define( 'WP_FIELDS_API_PLUGIN_VERSION', $api_version );
 
 	require_once( WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/class-wp-fields-api.php' );
 
@@ -54,7 +57,7 @@ function _wp_fields_api_include() {
 
 }
 
-add_action( 'plugins_loaded', '_wp_fields_api_include', 8 );
+add_action( 'plugins_loaded', '_wp_fields_api_include', 8, 0 );
 
 /**
  * Implement Fields API Customizer instead of WP Core Customizer.

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -62,7 +62,7 @@ class WP_Fields_API_v_0_1_0 {
 	/**
 	 * On `plugins_loaded`, create an instance of the Fields API manager class.
 	 */
-	function attempt_include() {
+	public function attempt_include() {
 
 		// Bail if we're already in WP core (depending on the name used)
 		if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -30,6 +30,26 @@ if ( defined( 'WP_FIELDS_API_TESTING' ) && WP_FIELDS_API_TESTING && ! empty( $_G
 define( 'WP_FIELDS_API_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WP_FIELDS_API_URL', plugin_dir_url( __FILE__ ) );
 
+
+function _wp_fields_api_warn_multiple_copies() {
+	$version = '0.1.0';
+	?>
+	<div class="notice notice-warning">
+		<p>
+			A plugin is trying to include an older version
+			(<?php echo $version; ?> <= <?php echo WP_FIELDS_API_PLUGIN_VERSION; ?>)
+			of the <strong>WP Fields API</strong>.
+		</p>
+		<p>
+			This might not cause problems, but
+			you should contact the plugin author and ask
+			them to update their plugin (trying to load the Fields API from
+			<code><?php echo __FILE__; ?></code>).
+		</p>
+	</div>
+	<?php
+}
+
 /**
  * On `plugins_loaded`, create an instance of the Fields API manager class.
  */
@@ -37,14 +57,7 @@ function _wp_fields_api_include( $api_version = '0.1.0' ) {
 
 	// Bail if we're already in WP core (depending on the name used)
 	if ( class_exists( 'WP_Fields_API' ) || class_exists( 'Fields_API' ) ) {
-		$included_fields_version = WP_FIELDS_API_PLUGIN_VERSION;
-		$file = plugin_dir_path( __FILE__ );
-		
-		// echo "A plugin is trying to include an older version "
-		// 	. "($api_version <= $included_fields_version) "
-		// 	. "of the WP Fields API. This might not cause problems, but "
-		// 	. "you should contact the plugin ($file) author and ask "
-		// 	. "them to update their plugin";
+		add_action( 'admin_notices', '_wp_fields_api_warn_multiple_copies' );
 
 		return;
 	}

--- a/wordpress-fields-api.php
+++ b/wordpress-fields-api.php
@@ -67,6 +67,9 @@ if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
 			/* remove_action( 'plugins_loaded', '_wp_customize_include' );
 			 add_action( 'plugins_loaded', array( $this, 'include_wp_customizer' ), 9 ); */
 
+			// @todo make this optional!
+	 		add_action( 'fields_register', array( $this, 'include_default_forms' ), 5 );
+
 		}
 
 		/**
@@ -101,6 +104,12 @@ if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
 
 		}
 
+		/**
+		 * Echo a warning on admin pages if multiple copies of this plugin 
+		 * are installed.
+		 * @todo modify this warning if WP Fields is part of core :)
+		 * @return void
+		 */
 		public function warn_about_multiple_copies() {
 			?>
 			<div class="notice notice-warning">
@@ -117,6 +126,66 @@ if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
 				</p>
 			</div>
 			<?php
+		}
+
+		/**
+		 * Include some basic forms (post edit, etc)
+		 * @todo make this optional!
+		 */
+		public function include_default_forms() {
+			global $wp_fields;
+
+			$implementation_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/forms/';
+
+			// Meta boxes
+			add_action( 'add_meta_boxes', array( 'WP_Fields_API_Meta_Box_Section', 'add_meta_boxes' ), 10, 2 );
+
+			// Post
+			require_once( $implementation_dir . 'class-wp-fields-api-form-post.php' );
+
+			$wp_fields->register_form_type( 'post-edit', 'WP_Fields_API_Form_Post' );
+			$wp_fields->add_form( 'post', 'post-edit', array(
+				'type' => 'post-edit',
+				'object_subtype' => 'post-edit',
+			) );
+
+			// Term
+			require_once( $implementation_dir . 'class-wp-fields-api-form-term.php' );
+			require_once( $implementation_dir . 'class-wp-fields-api-form-term-add.php' );
+
+			$wp_fields->register_form_type( 'term-edit', 'WP_Fields_API_Form_Term' );
+			$wp_fields->register_form_type( 'term-add', 'WP_Fields_API_Form_Term_Add' );
+
+			$wp_fields->add_form( 'term', 'term-edit', array(
+				'type' => 'term-edit',
+				'object_subtype' => 'term-edit',
+			) );
+
+			$wp_fields->add_form( 'term', 'term-add', array(
+				'type' => 'term-add',
+				'object_subtype' => 'term-add',
+			) );
+
+			// User
+			require_once( $implementation_dir . 'class-wp-fields-api-form-user-edit.php' );
+
+			$wp_fields->register_form_type( 'user-edit', 'WP_Fields_API_Form_User_Edit' );
+			$wp_fields->add_form( 'user', 'user-edit', array(
+				'type' => 'user-edit',
+				'object_subtype' => 'user-edit',
+			) );
+
+			// Comment
+			require_once( $implementation_dir . 'class-wp-fields-api-form-comment.php' );
+
+			$wp_fields->register_form_type( 'comment-edit', 'WP_Fields_API_Form_Comment' );
+			$wp_fields->add_form( 'comment', 'comment-edit', array(
+				'type' => 'comment-edit',
+				'object_subtype' => 'comment-edit',
+			) );
+
+
+
 		}
 
 		/**
@@ -137,66 +206,6 @@ if( ! class_exists( 'WP_Fields_API_v_0_1_0' ) ) {
 	}
 
 	WP_Fields_API_v_0_1_0::initialize();
-
-	/**
-	 * Include Implementations
-	 */
-	function _wp_fields_api_implementations() {
-		global $wp_fields;
-
-		$implementation_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/forms/';
-
-		// Meta boxes
-		add_action( 'add_meta_boxes', array( 'WP_Fields_API_Meta_Box_Section', 'add_meta_boxes' ), 10, 2 );
-
-		// Post
-		require_once( $implementation_dir . 'class-wp-fields-api-form-post.php' );
-
-		$wp_fields->register_form_type( 'post-edit', 'WP_Fields_API_Form_Post' );
-		$wp_fields->add_form( 'post', 'post-edit', array(
-			'type' => 'post-edit',
-			'object_subtype' => 'post-edit',
-		) );
-
-		// Term
-		require_once( $implementation_dir . 'class-wp-fields-api-form-term.php' );
-		require_once( $implementation_dir . 'class-wp-fields-api-form-term-add.php' );
-
-		$wp_fields->register_form_type( 'term-edit', 'WP_Fields_API_Form_Term' );
-		$wp_fields->register_form_type( 'term-add', 'WP_Fields_API_Form_Term_Add' );
-
-		$wp_fields->add_form( 'term', 'term-edit', array(
-			'type' => 'term-edit',
-			'object_subtype' => 'term-edit',
-		) );
-
-		$wp_fields->add_form( 'term', 'term-add', array(
-			'type' => 'term-add',
-			'object_subtype' => 'term-add',
-		) );
-
-		// User
-		require_once( $implementation_dir . 'class-wp-fields-api-form-user-edit.php' );
-
-		$wp_fields->register_form_type( 'user-edit', 'WP_Fields_API_Form_User_Edit' );
-		$wp_fields->add_form( 'user', 'user-edit', array(
-			'type' => 'user-edit',
-			'object_subtype' => 'user-edit',
-		) );
-
-		// Comment
-		require_once( $implementation_dir . 'class-wp-fields-api-form-comment.php' );
-
-		$wp_fields->register_form_type( 'comment-edit', 'WP_Fields_API_Form_Comment' );
-		$wp_fields->add_form( 'comment', 'comment-edit', array(
-			'type' => 'comment-edit',
-			'object_subtype' => 'comment-edit',
-		) );
-
-
-
-	}
-	add_action( 'fields_register', '_wp_fields_api_implementations', 5 );
 
 	// Post
 	add_action( 'load-post.php', '_wp_fields_api_load_include', 999 );


### PR DESCRIPTION
# Do not merge; opened for discussion

# Goal

Bring the Fields API into production by making it easy to write plugins that use it; replacement of core fields can come later.

# Proposal

The best solution seems to be making this a Composer plugin, intended to be bundled with a plugin that uses it, installed as its own plugin, or installed as a must-use plugin.

It is possible, albeit confusing, to support all of these *at once*, to some degree. The biggest problem is dependency hell, which we can mitigate. [WP-SCP Framework](https://github.com/scribu/wp-scb-framework/blob/95b23ac342fce16bf5eb8d939ac5a361b94b104b/load.php) and [CMB2](https://github.com/CMB2/CMB2/blob/21543641cf01fcc83cdd57ac167c53f1f2419d14/init.php) are both written to automatically include only the latest version if multiple copies are installed; with a relatively simple addition we can also generate warning messages admin-side if conflicting versions exist.

Practically, we would:

1. At plugin load-time, queue all copies of this plugin, no matter where they are located
2. After plugins load, load the most recent version into its global, firing form-registration hooks etc
3. If more than one version is present, display a warning on the admin screen

This change will also make **replacing core forms optional**, since that is the most brittle and experimental part of this project.

## Pitfalls

There are some potential downsides, though, hence the discussion pull request:

- This is not how the REST API was implemented; [their bootstrap process](https://github.com/WP-API/WP-API/blob/develop/composer.json) was rudimentary, "first to load" (`if( ! class_exists() )`)
- This API is not stable. Breaking changes to the API will break plugins that depend on earlier versions of the API, even if they include their own copies of it, since we load the most recent version no matter what. Our implementation can *warn* about this, but not prevent it.

The relevant discussions I saw, like [dependency hell](http://wptavern.com/a-narrative-of-using-composer-in-a-wordpress-plugin) and [WP core dev unhappiness](https://make.wordpress.org/plugins/2016/03/01/please-do-not-submit-frameworks/) (also see [Justin Sternberg's musings about this](https://dsgnwrks.pro/open-source/what-is-the-future-of-cmb2/) and [an issue on including frameworks](https://wordpress.org/support/topic/how-to-use-cmb2-inside-new-plugins/?replies=1) that he linked), though all over a year old, indicate that including frameworks (like this) in plugin code is frowned upon. However, this "framework" is plotting for core inclusion. As far as I can tell, we can craft a bootstrap process that behaves nicely *and* defers to any eventual core implementation.

## Alternatives

- We could package solely as a WP plugin; developers could check for our code ([`is_plugin_active`](http://codex.wordpress.org/Function_Reference/is_plugin_active) or something) and warn if our plugin is not installed

# Final thoughts

Unfortunately, this is the best suggestion I could come up with; I spent a while thinking about implementation and I'm pretty sure we can have a nice UX for dependency hell.

I'd love any thoughts on this; any suggestions?

# Action items

- [x] Encapsulate plugin bootstrap into namespace-ing class.
- [ ] Decide on version-update mechanism and write appropriate tests
- [ ] Transition unnecessary `define`s to class/instance variables
- [ ] Make default (`wp-admin/`) form replacement optional
- [ ] Localize strings 😲 
- [ ] TODO [below](https://github.com/sc0ttkclark/wordpress-fields-api/pull/91#issuecomment-319172561)