### PR TITLE
Rearranged user research docs

### DIFF
--- a/docs/research.md
+++ b/docs/research.md
@@ -18,11 +18,9 @@ implementation.
 * [Taxonomies](research/core/taxonomies.md)
     * Add term form
     * Edit term form (separate from the Add term form in how you work with it)
-* Users
-    * [User profile / edit form](research/core/users.md)
-    * Add new user form
-    * Add new user form (/network/ variation)
-    * Add existing user to site form (Multisite)
+* [Users](research/core/users.md)
+    * [User profile / edit form](research/core/user-edit.md)
+    * [Add new user form](research/core/user-new.md)
 * Media - Media modal
 * Comments - Add new comment (front of site)
 * Block Editor

--- a/docs/research/core/user-edit.md
+++ b/docs/research/core/user-edit.md
@@ -1,0 +1,67 @@
+# Profile / Edit User
+
+Users typically updated via `user-edit.php` unless a user is editing their own profile, these edits occur in `profile.php`.
+
+## Registering New Usermeta
+
+The user edit form contains actions which fire in two distinct locations within the form: 
+
+### Action: `personal_options`
+
+Use the `personal_options` action to add usermeta to the "personal option" section of at the top of the user edit form (see  [wp-admin/user-edit.php](https://github.com/WordPress/WordPress/blob/099ec7eec8fb89d48a0a1239c8ead5aa58a81295/wp-admin/user-edit.php#L394))
+
+```php
+add_action( 'personal_options', 'setup_personal_options' );
+
+public function setup_personal_options() {
+    ?>
+    <th>
+        <label for="new_meta_key">New Meta Name</label>
+    </th>
+    <td>
+		<input type="text" name="new_meta_key" id="new_meta_key"
+			value="<?php echo esc_attr( get_user_meta( $user->ID, 'new_meta_key', true ) ); ?>"
+			class="regular-text"/>
+    </td>
+    <?php
+}
+```
+
+### Adding Usermeta Sections
+
+There are 3 actions that can be used to add new _sections_ of usermeta: 
+- `profile_personal_options` fires on `profile.php` immediately below the "Personal Option" section.
+- `show_user_profile` fires on `profile.php` near the end of the edit form (see [wp-admin/user-edit.php](https://github.com/WordPress/WordPress/blob/30ffb247b7667516a388d5dd968c2cbd1766cddb/wp-admin/user-edit.php#L835-L844)).
+- `edit_user_profile` fires on `user-edit.php` in the same location as `show_user_profile` (see [wp-admin/user-edit.php](https://github.com/WordPress/WordPress/blob/30ffb247b7667516a388d5dd968c2cbd1766cddb/wp-admin/user-edit.php#L846-L853)).
+
+
+```php
+// ONLY profile.php below "Personal Options" 
+add_action( 'profile_personal_options', 'setup_user_fields' );
+// profile.php near the end of the form
+add_action( 'show_user_profile', 'setup_user_fields' );
+// user-edit.php near the end of the form
+add_action( 'edit_user_profile', 'setup_user_fields' );
+
+public function setup_user_fields( $user ) {
+	?>
+      <h2>New Section</h2>	
+	  <table class="form-table">
+		  <tr>
+			  <th><label for="new_meta_key">New Meta Name</label></th>
+			  <td>
+				<input type="text" name="new_meta_key" id="new_meta_key"
+						value="<?php echo esc_attr( get_user_meta( $user->ID, 'new_meta_key', true ) ); ?>"
+						class="regular-text"/>
+			  </td>
+		  </tr>
+	  </table>
+	<?php
+}
+```
+
+_Tip:_ It may be beneficial to reuse `setup_user_fields()` in the context of the user edit form. See [Add User](user-new.md) for relevant action.
+
+## Saving
+
+See [User Meta](users.md)

--- a/docs/research/core/user-new.md
+++ b/docs/research/core/user-new.md
@@ -1,0 +1,45 @@
+# Add User 
+
+## Action: `user_new_form`
+
+The add user form (`user-new.php`) contains one action that can be used for register new usermeta fields.
+
+### Example Registration
+
+This action fires after the main `<table>` of fields, immediately before the submit button. 
+
+So an entire table with header is needed to register new fields.
+
+```php
+add_action( 'user_new_form', 'setup_user_fields' );
+
+public function setup_user_fields( $user ) {
+	?>
+      <h2>New Section</h2>	
+	  <table class="form-table">
+		  <tr>
+			  <th><label for="new_meta_key">New Meta Name</label></th>
+			  <td>
+				<input type="text" name="new_meta_key" id="new_meta_key"
+						value="<?php echo esc_attr( get_user_meta( $user->ID, 'new_meta_key', true ) ); ?>"
+						class="regular-text"/>
+			  </td>
+		  </tr>
+	  </table>
+	<?php
+}
+```
+
+_Tip:_ It may be beneficial to reuse `setup_user_fields()` in the context of the user edit form. See [User Profile / Edit User](user-edit.md) for relevant actions.
+
+
+### Multisite
+
+Multisite installs use this same action. 
+
+When adding a new user in the context of an individual site this action fires in the "add existing user" and "add new uesr" sections.
+
+
+## Saving 
+
+See [User Meta](users.md)

--- a/docs/research/core/users.md
+++ b/docs/research/core/users.md
@@ -1,68 +1,30 @@
 # User Meta
 
-This research covers user meta in the context of the user management feature in wp-admin.
-
-## Registering New Usermeta
-
-### Adding "Personal Options"
-
-Use the `personal_options` action to add usermeta to the "personal option" section of at the top of the user edit form (see  [wp-admin/user-edit.php](https://github.com/WordPress/WordPress/blob/099ec7eec8fb89d48a0a1239c8ead5aa58a81295/wp-admin/user-edit.php#L394))
-
-```php
-add_action( 'personal_options', 'setup_personal_options' );
-
-public function setup_personal_options() {
-    ?>
-    <th>
-        <label for="new_meta_key">New Meta Name</label>
-    </th>
-    <td>
-		<input type="text" name="new_meta_key" id="new_meta_key"
-			value="<?php echo esc_attr( get_user_meta( $user->ID, 'new_meta_key', true ) ); ?>"
-			class="regular-text"/>
-    </td>
-    <?php
-}
-```
-
-### Adding Usermeta Sections
-
-There are 3 actions that can be used to add new _sections_ of usermeta: 
-- `profile_personal_options` fires on `profile.php` immediately below the "Personal Option" section.
-- `show_user_profile` fires on `profile.php` near the end of the edit form (see [wp-admin/user-edit.php](https://github.com/WordPress/WordPress/blob/30ffb247b7667516a388d5dd968c2cbd1766cddb/wp-admin/user-edit.php#L835-L844)).
-- `edit_user_profile` fires on `user-edit.php` in the same location as `show_user_profile` (see [wp-admin/user-edit.php](https://github.com/WordPress/WordPress/blob/30ffb247b7667516a388d5dd968c2cbd1766cddb/wp-admin/user-edit.php#L846-L853)).
+This section of research covers adding and editing usermeta fields to the various wp-admin forms.
 
 
-```php
-// ONLY profile.php below "Personal Options" 
-add_action( 'profile_personal_options', 'setup_user_fields' );
-// profile.php near the end of the form
-add_action( 'show_user_profile', 'setup_user_fields' );
-// user-edit.php near the end of the form
-add_action( 'edit_user_profile', 'setup_user_fields' );
+## Registering Custom Usermeta Fields
 
-public function setup_user_fields( $user ) {
-	?>
-      <h2>New Section</h2>	
-	  <table class="form-table">
-		  <tr>
-			  <th><label for="new_meta_key">New Meta Name</label></th>
-			  <td>
-				<input type="text" name="new_meta_key" id="new_meta_key"
-						value="<?php echo esc_attr( get_user_meta( $user->ID, 'new_meta_key', true ) ); ?>"
-						class="regular-text"/>
-			  </td>
-		  </tr>
-	  </table>
-	<?php
-}
-```
+"Registering" new usermeta fields must be accomplished by echoing HTML via different actions depending on the context.
 
-## Saving
+In some contexts, you must echo a single table row, while in others you will need to echo an entire table, perhaps including a header as well. 
 
+_Note:_ It is important to include the wp-admin css classes so the new fields blend in with the admin. 
+
+**See**
+
+- [Add User](user-new.md)
+- [Profile / Edit User](user-edit.md)
+
+
+## Saving Custom Usermeta Fields
+
+All user forms `include 'user.php'` and use the `edit_form()` function to perform user insert and updates. Yes, _adding_ users also uses the `edit_user()` function.  
+
+### Filter: `insert_custom_user_meta`
 The `insert_custom_user_meta` filter appends an arbitrary array immediately prior to running `update_user_meta()` with each element in the array inside `wp_insert_user()` (see [wp-includes/user.php](https://github.com/WordPress/WordPress/blob/30ffb247b7667516a388d5dd968c2cbd1766cddb/wp-includes/user.php#L2430)).
 
-To attach a new meta we inform `wp_insert_user()` about the previously unassigned `$_POST` value. 
+To attach a new meta we inform `wp_insert_user()` about the previously unassigned `$_POST` value.
 
 ```php
 add_filter( 'insert_custom_user_meta', 'attach_new_meta_field' );


### PR DESCRIPTION
I rearranged the docs to hopefully provide some clarity and avoid duplication.

As best as I can tell, multi-site shares actions with single-site, I don't think it warrants its own section. There is a bit of a quirk will it will duplicate the fields in one case, which I've highlighted.

Please suggestion or commit any improvements.