### PR TITLE
PoC - A Fields API based on the Customizer API

### DIFF
--- a/class-wp-fields-api-component.php
+++ b/class-wp-fields-api-component.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * WordPress Fields API Component class
+ *
+ * @package WordPress
+ * @subpackage Fields API
+ */
+
+/**
+ * Fields API Component class.
+ */
+class WP_Fields_API_Component {
+	/**
+	 * Order in which this instance was created in relation to other instances.
+	 *
+	 * @access public
+	 * @var int
+	 */
+	public $instance_number;
+
+	/**
+	 * Unique identifier.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Type of container to use by default if no registered
+	 * type is specified
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $type = 'default';
+
+	/**
+	 * Object type.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $object_type = null;
+
+	/**
+	 * Object subtype (for post types and taxonomies).
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $object_subtype = null;
+
+	/**
+	 * Parent container
+	 *
+	 * @access public
+	 * @var WP_Fields_API_Container
+	 */
+	public $parent = null;
+
+	/**
+	 * Capability required for the component.
+	 *
+	 * @access public
+	 * @var string|array
+	 */
+	public $capability;
+
+	/**
+	 * Capabilities Callback.
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Component::check_capabilities()
+	 *
+	 * @var callable Callback is called with one argument, the instance of
+	 *               WP_Fields_API_Container, and returns bool to indicate whether
+	 *               the container has capabilities to be used.
+	 */
+	public $capabilities_callback;
+
+	/**
+	 * Theme feature support for the container.
+	 *
+	 * @access public
+	 * @var string|array
+	 */
+	public $theme_supports;
+
+	/**
+	 * @access public
+	 * @var int
+	 */
+	public $priority = 10;
+
+	/**
+	 * True opens up the maybe render method
+	 *
+	 * @access public
+	 * @var boolean
+	 */
+	public $can_render = true;
+
+	/**
+	 * Render Callback.
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Container::render()
+	 *
+	 * @var callable Callback is called with one argument, the instance of
+	 *               WP_Fields_API_Container.
+	 */
+	public $render_callback;
+
+	/**
+	 * Create new component
+	 *
+	 * @access public
+	 *
+	 * @param string $id ID for this component
+	 * @param array $args Additional container args to set
+	 */
+	public function __construct( $id, $args = array() ) {
+		$this->id = $id;
+
+		foreach ( $args as $property => $value ) {
+			if ( isset( $this->{$property} ) && is_array( $this->{$property} ) ) {
+				$this->{$property} = array_merge( $this->{$property}, $value );
+			} else {
+				$this->{$property} = $value;
+			}
+		}
+
+		$this->instance_number = $this->get_next_instance_number();
+
+		/**
+		 * Let people implement this method instead of the constructor so they don't have to remember constructor args
+		 */
+		$this->setup();
+	}
+
+	/**
+	 * Any component specific setup here
+	 */
+	public function setup() {
+
+		// Do nothing by default
+
+	}
+
+	/**
+	 * Get object type for a container. We might have to check the parent container
+	 *
+	 * @access public
+	 *
+	 * @return string|null
+	 */
+	public function get_object_type() {
+
+		$object_type = null;
+
+		if ( empty( $this->parent ) ) {
+			$object_type = $this->object_type;
+		} else {
+			$object_type = $this->parent->get_object_type();
+		}
+
+		return $object_type;
+
+	}
+
+	/**
+	 * Get object type for a container. We might have to check the parent container
+	 *
+	 * @access public
+	 *
+	 * @return string|null
+	 */
+	public function get_object_subtype() {
+
+		$object_subtype = null;
+
+		if ( empty( $this->parent ) ) {
+			$object_subtype = $this->object_subtype;
+		} else {
+			$object_subtype = $this->parent->get_object_subtype();
+		}
+
+		return $object_subtype;
+
+	}
+
+	/**
+	 * Get internal instance number to use for a new form component
+	 *
+	 * @access public
+	 *
+	 * @return int
+	 */
+	public function get_next_instance_number() {
+		static $instance_count = 0;
+
+		$instance_count ++;
+
+		return $instance_count;
+	}
+
+	/**
+	 * Helper function to compare two objects by priority, ensuring sort stability via instance_number.
+	 *
+	 * @access public
+	 *
+	 * @param WP_Fields_API_Container $a Object A.
+	 * @param WP_Fields_API_Container $b Object B.
+	 *
+	 * @return int
+	 */
+	public function _cmp_priority( $a, $b ) {
+
+		$compare = 0;
+
+		if ( isset( $a->priority ) || isset( $b->priority ) ) {
+			$priorities = array(
+				'high'    => 0,
+				'core'    => 100,
+				'default' => 200,
+				'low'     => 300,
+			);
+
+			// Set defaults
+			$a_priority = $priorities['default'];
+			$b_priority = $priorities['default'];
+
+			if ( isset( $a->priority ) ) {
+				$a_priority = $a->priority;
+			}
+
+			if ( isset( $b->priority ) ) {
+				$b_priority = $b->priority;
+			}
+
+			// Convert string priority
+			if ( ! is_int( $a_priority ) ) {
+				if ( isset( $priorities[ $a_priority ] ) ) {
+					$a_priority = $priorities[ $a_priority ];
+				} else {
+					$a_priority = $priorities['default'];
+				}
+			}
+
+			// Convert string priority
+			if ( ! is_int( $b_priority ) ) {
+				if ( isset( $priorities[ $b_priority ] ) ) {
+					$b_priority = $priorities[ $b_priority ];
+				} else {
+					$b_priority = $priorities['default'];
+				}
+			}
+
+			// Priority integers
+			$compare = $a_priority - $b_priority;
+
+			// Tie breakers can use instance number
+			if ( $a_priority === $b_priority && isset( $a->instance_number ) && isset( $b->instance_number ) ) {
+				$compare = $a->instance_number - $b->instance_number;
+			}
+		}
+
+		return $compare;
+
+	}
+
+	/**
+	 * Check capabilities and render the container.
+	 */
+	public function maybe_render() {
+		if ( ! $this->check_capabilities() ) {
+			return;
+		}
+
+		// Enqueue assets
+		if ( method_exists( $this, 'enqueue' ) && ! has_action( 'admin_footer', array( $this, 'enqueue' ) ) ) {
+			add_action( 'admin_footer', array( $this, 'enqueue' ) );
+		}
+
+		if ( is_callable( $this->render_callback ) ) {
+			call_user_func( $this->render_callback, $this );
+		} else {
+			$this->render();
+		}
+	}
+
+	/**
+	 * Render the container.
+	 */
+	protected function render() {
+		// Default is to do nothing
+	}
+
+	/**
+	 * Checks required user capabilities and whether the theme has the
+	 * feature support required by the container.
+	 *
+	 * @return bool False if theme doesn't support the container or user can't change container, otherwise true.
+	 */
+	public function check_capabilities() {
+		if ( $this->capability && ! call_user_func_array( 'current_user_can', (array) $this->capability ) ) {
+			return false;
+		}
+
+		if ( $this->theme_supports && ! call_user_func_array( 'current_theme_supports', (array) $this->theme_supports ) ) {
+			return false;
+		}
+
+		$access = true;
+		if ( is_callable( $this->capabilities_callback ) ) {
+			$access = call_user_func( $this->capabilities_callback, $this );
+		}
+
+		$access = apply_filters( "fields_api_check_capabilities", $access, $this );
+
+		return $access;
+	}
+}

--- a/class-wp-fields-api-container.php
+++ b/class-wp-fields-api-container.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * WordPress Fields API Container class
+ *
+ * @package WordPress
+ * @subpackage Fields API
+ */
+
+/**
+ * Fields API Container class.
+ */
+class WP_Fields_API_Container extends WP_Fields_API_Component {
+
+	/**
+	 * Hold children form components
+	 *
+	 * @access public
+	 * @var array
+	 */
+	public $children = array();
+
+	/**
+	 * Type of container
+	 *
+	 * @var string
+	 */
+	public $container_type;
+
+	/**
+	 * Type of child container
+	 * @var string
+	 */
+	public $child_container_type;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct( $id, $args = array() ) {
+
+		// Reserved properties
+		if ( isset( $args['container_type'] ) ) {
+			unset( $args['container_type'] );
+		}
+
+		if ( isset( $args['child_container_type'] ) ) {
+			unset( $args['child_container_type'] );
+		}
+
+		if ( isset( $args['children'] ) ) {
+			unset( $args['children'] );
+		}
+
+		parent::__construct( $id, $args );
+
+		if ( $this->container_type ) {
+			if ( $this->id ) {
+				// @todo Hook docs
+				do_action( 'fields_setup_' . $this->container_type . '_' . $this->id, $this );
+			}
+
+			// @todo Hook docs
+			do_action( 'fields_setup_' . $this->container_type, $this );
+		}
+
+	}
+
+	/**
+	 * Get a child component by id
+	 *
+	 * @access public
+	 *
+	 * @param string $id ID for child component
+	 *
+	 * @return WP_Fields_API_Component|false
+	 */
+	public function get_child( $id ) {
+
+		if ( empty( $this->children[ $id ] ) ) {
+			return false;
+		}
+
+		return $this->children[ $id ];
+
+	}
+
+	/**
+	 * Get all child components and optionally filter by subtype
+	 *
+	 * @access public
+	 *
+	 * @param string $object_subtype Object subtype (for post types and taxonomies).
+	 *
+	 * @return array
+	 */
+	public function get_children( $object_subtype = null ) {
+
+		$children = $this->children;
+
+		if ( ! empty( $object_subtype ) ) {
+			foreach ( $children as $key => $child ) {
+				if ( $object_subtype !== $child->object_subtype ) {
+					unset( $children[ $key ] );
+				}
+			}
+		}
+
+		return $children;
+
+	}
+
+	/**
+	 * Add a child component to the container
+	 *
+	 * @access public
+	 *
+	 * @param string $id ID for this component
+	 * @param array|WP_Fields_API_Container $args Additional container args to set
+	 *
+	 * @return WP_Fields_API_Container|WP_Error
+	 */
+	public function add_child( $id, $args = array() ) {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		if ( empty( $id ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-id-required', __( 'ID is required.', 'fields-api' ) );
+		}
+
+		if ( ! empty( $this->children[ $id ] ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-id-exists', __( 'ID already exists.', 'fields-api' ) );
+		}
+
+		$class = $wp_fields->get_registered_type( $this->child_container_type, 'default' );
+
+		if ( is_a( $args, $class ) ) {
+			/**
+			 * @var $child WP_Fields_API_Container
+			 */
+			$child = $args;
+
+			$child->parent = $this;
+		} else {
+			if ( is_object( $args ) ) {
+				// @todo Need WP_Error code
+				return new WP_Error( 'fields-api-unexpected-object', __( 'Unexpected object.', 'fields-api' ) );
+			}
+
+			if ( ! empty( $args['type'] ) ) {
+				$class = $wp_fields->get_registered_type( $this->child_container_type, $args['type'] );
+			}
+
+			$args['parent'] = $this;
+
+			$child = new $class( $id, $args );
+		}
+
+		$this->children[ $id ] = $child;
+
+		return $child;
+
+	}
+
+	/**
+	 * Remove a child component by id
+	 *
+	 * @access public
+	 *
+	 * @param string $id ID for child component
+	 */
+	public function remove_child( $id ) {
+
+		foreach ( $this->children as $key => $child ) {
+			if ( $id === $child->id || ( is_object( $id ) && $id === $child ) ) {
+				$this->children[ $key ]->parent = null;
+
+				unset( $this->children[ $key ] );
+			}
+		}
+
+	}
+
+	/**
+	 * Remove child components
+	 *
+	 * @access public
+	 */
+	public function remove_children() {
+
+		$this->children = array();
+
+	}
+
+	/**
+	 * Gather the parameters passed to client JavaScript via JSON.
+	 *
+	 * @return array The array to be exported to the client as JSON.
+	 */
+	public function json() {
+
+		$json                   = wp_array_slice_assoc( (array) $this, array(
+			'container_type',
+			'id',
+			'type',
+			'priority'
+		) );
+		$json['instanceNumber'] = $this->instance_number;
+
+		$json['objectType']    = $this->get_object_type();
+		$json['objectSubtype'] = $this->object_subtype;
+
+		// Get parent
+		$json['parent']     = '';
+		$json['parentType'] = '';
+
+		$parent = $this->parent;
+
+		if ( $parent ) {
+			$json['parent']     = $parent->id;
+			$json['parentType'] = $parent->container_type;
+		}
+
+		// Get children
+		$json['children'] = array();
+
+		$children = $this->get_children( null );
+
+		if ( $children ) {
+			/**
+			 * @var $child_type_children array
+			 */
+			foreach ( $children as $child_type => $child_type_children ) {
+				$json['children'][ $child_type ] = wp_list_pluck( $child_type_children, 'id' );
+			}
+		}
+
+		return $json;
+
+	}
+
+}

--- a/class-wp-fields-api-control.php
+++ b/class-wp-fields-api-control.php
@@ -1,0 +1,651 @@
+<?php
+
+/**
+ * Fields API Control Class
+ *
+ * @package WordPress
+ * @subpackage Fields_API
+ *
+ * @property array $choices Key/Values used by Multiple choice control types
+ */
+class WP_Fields_API_Control extends WP_Fields_API_Component {
+
+	/**
+	 * Label to render
+	 *
+	 * @var string
+	 */
+	public $label;
+
+	/**
+	 * Show label or not
+	 *
+	 * @var bool
+	 */
+	public $display_label;
+
+	/**
+	 * Description to render
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * Description callback function to execute
+	 *
+	 * @var callback
+	 */
+	public $description_callback;
+
+	/**
+	 * Item ID of current item passed to WP_Fields_API_Field for value()
+	 *
+	 * @access public
+	 * @var int|string
+	 */
+	public $item_id = 0;
+
+	/**
+	 * @access public
+	 * @var array
+	 */
+	public $input_attrs = array();
+
+	/**
+	 * @access public
+	 * @var array
+	 */
+	public $wrap_attrs = array();
+
+	/**
+	 * @access public
+	 * @var string
+	 */
+	public $type = 'text';
+
+	/**
+	 * Contains field object
+	 *
+	 * @var WP_Fields_API_Field|null
+	 */
+	public $field = null;
+
+	/**
+	 * Datasource type for control
+	 *
+	 * @access public
+	 * @var WP_Fields_API_Datasource
+	 */
+	public $datasource = null;
+
+	/**
+	 * Choices callback
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Control::setup_choices()
+	 *
+	 * @var callable Callback is called with one argument, the instance of WP_Fields_API_Control.
+	 *               It returns an array of choices for the control to use.
+	 */
+	public $choices_callback = null;
+
+	/**
+	 * Render callback
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Control::render_content()
+	 *
+	 * @var callable Callback is called with one argument, the instance of WP_Fields_API_Control.
+	 *               It outputs an input for the control to use.
+	 */
+	public $render_callback = null;
+
+	/**
+	 * List of control types that have had their templates printed to screen
+	 *
+	 * @access private
+	 * @var array
+	 */
+	private static $printed_templates = array();
+
+	/**
+	 * Store save errors for this control
+	 *
+	 * @access public
+	 * @var WP_Error
+	 */
+	public $error = null;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct( $id, $args = array() ) {
+
+		$field      = null;
+		$datasource = null;
+
+		if ( isset( $args['field'] ) ) {
+			if ( ! empty( $args['field'] ) ) {
+				$field = $args['field'];
+			}
+
+			unset( $args['field'] );
+		}
+
+		if ( isset( $args['datasource'] ) ) {
+			if ( ! empty( $args['datasource'] ) ) {
+				$field = $args['datasource'];
+			}
+
+			unset( $args['datasource'] );
+		}
+
+		parent::__construct( $id, $args );
+
+		if ( $field ) {
+			$field_id   = $field;
+			$field_args = array();
+
+			if ( ! is_string( $field ) ) {
+				$field_id   = '';
+				$field_args = $field;
+			}
+
+			$this->add_field( $field_id, $field_args );
+		}
+
+		if ( $datasource ) {
+			$datasource_type = $datasource;
+			$datasource_args = array();
+
+			if ( ! is_string( $datasource ) ) {
+				$datasource_type = '';
+				$datasource_args = $datasource;
+			}
+
+			$this->add_datasource( $datasource_type, $datasource_args );
+		}
+
+	}
+
+	/**
+	 * Add field to control
+	 *
+	 * @param string $id Field ID
+	 * @param array|WP_Fields_API_Field $args Field arguments
+	 *
+	 * @return WP_Error|WP_Fields_API_Field
+	 */
+	public function add_field( $id, $args = array() ) {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		if ( is_a( $args, 'WP_Fields_API_Field' ) ) {
+			$id = $args->id;
+		} elseif ( ! is_array( $args ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-unexpected-arguments', __( 'Unexpected arguments.', 'fields-api' ) );
+		} elseif ( ! empty( $args['id'] ) ) {
+			$id = $args['id'];
+
+			unset( $args['id'] );
+		}
+
+		if ( empty( $id ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-id-required', __( 'ID is required.', 'fields-api' ) );
+		}
+
+		if ( ! empty( $this->field ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-field-exists', __( 'Field already exists.', 'fields-api' ) );
+		}
+
+		$object_type = $this->get_object_type();
+
+		if ( empty( $object_type ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-object-type-required', __( 'Object type is required.', 'fields-api' ) );
+		}
+
+		$field = null;
+
+		if ( empty( $args ) ) {
+			$field = $wp_fields->get_field( $object_type, $id );
+		}
+
+		if ( ! $field ) {
+			$field = $wp_fields->add_field( $object_type, $id, $args );
+		}
+
+		if ( $field && ! is_wp_error( $field ) ) {
+			if ( ! empty( $field->parent ) ) {
+				// @todo Need WP_Error code
+				return new WP_Error( 'fields-api-field-associated', __( 'Field already associated to another control.', 'fields-api' ) );
+			}
+
+			$this->field = $field;
+
+			$field->parent = $this;
+		}
+
+		return $field;
+
+	}
+
+	/**
+	 * Get field from control
+	 *
+	 * @return WP_Fields_API_Field|null
+	 */
+	public function get_field() {
+
+		return $this->field;
+
+	}
+
+	/**
+	 * Remove field from control
+	 */
+	public function remove_field() {
+
+		if ( $this->field ) {
+			$this->field->parent = null;
+		}
+
+		$this->field = null;
+
+	}
+
+	/**
+	 * Add datasource to control
+	 *
+	 * @param string $type Datasource type
+	 * @param array|WP_Fields_API_Datasource $args Datasource arguments
+	 *
+	 * @return WP_Error|WP_Fields_API_Datasource
+	 */
+	public function add_datasource( $type, $args = array() ) {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		$datasource = null;
+
+		if ( is_a( $args, 'WP_Fields_API_Datasource' ) ) {
+			$type = $args->type;
+
+			$datasource = $args;
+		} elseif ( ! empty( $args['type'] ) ) {
+			$type = $args['type'];
+
+			unset( $args['type'] );
+		} elseif ( ! is_array( $args ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-unexpected-arguments', __( 'Unexpected arguments.', 'fields-api' ) );
+		}
+
+		if ( empty( $type ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-datasource-type-required', __( 'Datasource Type is required.', 'fields-api' ) );
+		}
+
+		if ( ! empty( $this->datasource ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-datasource-exists', __( 'Datasource already exists on control.', 'fields-api' ) );
+		}
+
+		if ( ! $datasource ) {
+			$class = $wp_fields->get_registered_type( 'datasource', $type );
+
+			$datasource = new $class( $type, $args );
+		}
+
+		$this->datasource = $datasource;
+
+		return $datasource;
+
+	}
+
+	/**
+	 * Get datasource from control
+	 *
+	 * @return WP_Fields_API_Datasource|null
+	 */
+	public function get_datasource() {
+
+		return $this->datasource;
+
+	}
+
+	/**
+	 * Remove datasource from control
+	 */
+	public function remove_datasource() {
+
+		$this->datasource = null;
+
+	}
+
+	/**
+	 * Render the container description.
+	 */
+	public function render_description() {
+		if ( is_callable( $this->description_callback ) ) {
+			call_user_func( $this->description_callback, $this );
+
+			return;
+		}
+
+		if ( $this->description ) {
+			?>
+            <p class="description">
+				<?php echo wp_kses_post( $this->description ); ?>
+            </p>
+			<?php
+		}
+	}
+
+	/**
+	 * Get choice values
+	 */
+	public function choices() {
+
+		$data = array();
+
+		// If control has a datasource, use it for getting the data
+		if ( $this->datasource ) {
+			$args = array();
+
+			// @todo Needs hook docs
+			$args = apply_filters( "fields_control_datasource_get_args_{$this->datasource->type}", $args, $this->datasource, $this );
+
+			// @todo Needs hook docs
+			$args = apply_filters( "fields_control_datasource_get_args_{$this->datasource->type}_{$this->id}", $args, $this->datasource, $this );
+
+			// Get data from datasource
+			$data = $this->datasource->get_data( $args, $this );
+		}
+
+		return $data;
+
+	}
+
+	/**
+	 * Setup the choices values and set the choices property to allow dynamic building
+	 */
+	public function setup_choices() {
+
+		if ( ! isset( $this->choices ) ) {
+			if ( is_callable( $this->choices_callback ) ) {
+				$choices = call_user_func( $this->choices_callback, $this );
+			} else {
+				$choices = $this->choices();
+			}
+
+			$this->choices = $choices;
+		}
+
+	}
+
+	/**
+	 * Fetch a field's value.
+	 *
+	 * @return mixed The requested field's value, if the field exists.
+	 */
+	final public function value() {
+
+		$value = null;
+
+		if ( $this->field ) {
+			$value = $this->field->value( $this->get_item_id() );
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function check_capabilities() {
+
+		if ( ! $this->field || ! $this->field->check_capabilities() ) {
+			return false;
+		}
+
+		$section = $this->parent;
+
+		if ( $section && ! $section->check_capabilities() ) {
+			return false;
+		}
+
+		return parent::check_capabilities();
+
+	}
+
+	/**
+	 * Render HTML attributes safely to the screen.
+	 *
+	 * @access public
+	 *
+	 * @param array $attrs
+	 */
+	public function render_attrs( $attrs = array() ) {
+		foreach ( $attrs as $attr => $value ) {
+			echo esc_attr( $attr ) . '="' . esc_attr( $value ) . '" ';
+		}
+	}
+
+	/**
+	 * Renders the control wrapper and calls $this->render_content() for the internals.
+	 */
+	protected function render() {
+
+		$attrs = array(
+			'id'    => 'fields-control-' . str_replace( '[', '-', str_replace( ']', '', $this->id ) ),
+			'class' => 'fields-control fields-control-' . $this->type,
+		);
+		if ( is_wp_error( $this->error ) ) {
+			$attrs['class'] .= ' fields-error fields-error-code-' . esc_attr( $this->error->get_error_code() );
+		}
+
+		$input_attrs = $this->get_input_attrs();
+
+		$attrs['data-fields-type']       = $this->type;
+		$attrs['data-fields-input-name'] = $input_attrs['name'];
+		?>
+        <div <?php $this->render_attrs( $attrs ); ?>>
+			<?php
+			$render_control = true;
+
+			// Check if datasource will override control rendering
+			if ( $this->datasource ) {
+				if ( true === $this->datasource->render_control( $this ) ) {
+					$render_control = false;
+				}
+			}
+
+			// Check if we need to render this control
+			if ( $render_control ) {
+				$this->render_content();
+			}
+			?>
+        </div>
+		<?php
+
+	}
+
+	/**
+	 * Render the control's content.
+	 *
+	 * Allows the content to be overridden without having to rewrite the wrapper in $this->render().
+	 *
+	 * Supports input types such as `text`, `email`, `url`, `number`, `hidden` and `date` implicitly.
+	 *
+	 * Control content can alternately be rendered in JS. See {@see WP_Fields_API_Control::print_template()}.
+	 */
+	protected function render_content() {
+
+		if ( is_callable( $this->render_callback ) ) {
+			call_user_func( $this->render_callback, $this );
+
+			return;
+		}
+		?>
+        <input type="<?php echo esc_attr( $this->type ); ?>" <?php $this->input_attrs(); ?>
+               value="<?php echo esc_attr( $this->value() ); ?>" <?php $this->link(); ?> />
+
+		<?php if ( is_wp_error( $this->error ) ) : ?>
+            <span class="field-error-text"><?php echo esc_html( $this->error->get_error_message() ); ?></span>
+		<?php endif; ?>
+
+		<?php
+
+	}
+
+	/**
+	 * Get the data link attribute for a field.
+	 *
+	 * @return string Data link parameter, if field exists, empty string otherwise.
+	 */
+	public function get_link() {
+
+		if ( ! $this->field ) {
+			return '';
+		}
+
+		return ' data-fields-field-link="' . esc_attr( $this->field->id ) . '"';
+
+	}
+
+	/**
+	 * Render the data link attribute for the control's input element.
+	 */
+	public function link() {
+
+		echo $this->get_link();
+
+	}
+
+	/**
+	 * Get the input attributes for the control's input element.
+	 *
+	 * @access public
+	 * @return array
+	 */
+	public function get_input_attrs() {
+
+		// Setup field id / name
+		if ( ! isset( $this->input_attrs['id'] ) ) {
+			$this->input_attrs['id'] = 'field-' . $this->id;
+		}
+
+		if ( ! isset( $this->input_attrs['name'] ) ) {
+			$this->input_attrs['name'] = $this->id;
+		}
+
+		return $this->input_attrs;
+
+	}
+
+	/**
+	 * Render the custom attributes for the control's input element.
+	 *
+	 * @access public
+	 */
+	public function input_attrs() {
+
+		$this->render_attrs( $this->get_input_attrs() );
+
+	}
+
+	/**
+	 * Get the custom attributes for the control's wrapper element.
+	 *
+	 * @access public
+	 * @return array
+	 */
+	public function get_wrap_attrs() {
+
+		if ( ! isset( $this->wrap_attrs['class'] ) || false === strpos( $this->wrap_attrs['class'], 'fields-api-control' ) ) {
+			$classes = 'form-field ' . $this->object_type . '-' . $this->id . '-wrap field-' . $this->id . '-wrap fields-api-control';
+
+			if ( isset( $this->wrap_attrs['class'] ) ) {
+				$classes .= ' ' . $this->wrap_attrs['class'];
+			}
+
+			$this->wrap_attrs['class'] = $classes;
+		}
+
+		return $this->wrap_attrs;
+
+	}
+
+	/**
+	 * Render the custom attributes for the control's wrapper element.
+	 *
+	 * @access public
+	 */
+	public function wrap_attrs() {
+
+		$this->render_attrs( $this->get_wrap_attrs() );
+
+	}
+
+	/**
+	 * Enqueue scripts/styles as needed.
+	 *
+	 * @access public
+	 */
+	public function enqueue() {
+
+
+	}
+
+	/**
+	 * Render the control's JS template.
+	 *
+	 * This function is only run for control types that have been registered with
+	 * {@see WP_Fields_API::register_control_type()}.
+	 */
+	public function print_template() {
+
+		if ( in_array( $this->type, self::$printed_templates ) ) {
+			return;
+		}
+
+		self::$printed_templates[] = $this->type;
+		?>
+        <script type="text/html" id="tmpl-fields-control-<?php echo esc_attr( $this->type ); ?>-content">
+			<?php $this->content_template(); ?>
+        </script>
+		<?php
+
+	}
+
+	/**
+	 * An Underscore (JS) template for this control's content (but not its container).
+	 *
+	 * Class variables for this control class are available in the `data` JS object;
+	 * export custom variables by overriding {@see WP_Fields_API_Control::to_json()}.
+	 *
+	 * @see WP_Fields_API_Control::print_template()
+	 */
+	public function content_template() {
+
+		?>
+        <input type="{{ data.type }}" name="{{ data.input_name }}" value="{{ data.value }}" id="{{ data.input_id }}"/>
+		<?php
+
+	}
+
+}

--- a/class-wp-fields-api-datasource.php
+++ b/class-wp-fields-api-datasource.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * Fields API Datasource Class
+ *
+ * @package WordPress
+ * @subpackage Fields_API
+ */
+class WP_Fields_API_Datasource {
+
+	/**
+	 * Datasource type
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $type = 'default';
+
+	/**
+	 * Arguments to send to the datasource
+	 *
+	 * @access public
+	 * @var array
+	 */
+	public $get_args = array();
+
+	/**
+	 * Display in hierarchical context, if the datasource supports it
+	 *
+	 * @access public
+	 * @var bool
+	 */
+	public $hierarchical = false;
+
+	/**
+	 * Hierarchical fields for datasource
+	 *
+	 * @access public
+	 * @var array
+	 */
+	public $hierarchical_fields = array(
+		'id'            => 'id',
+		'parent'        => 'parent',
+		'title'         => 'title',
+		'default_title' => '',
+	);
+
+	/**
+	 * Create new component
+	 *
+	 * @access public
+	 *
+	 * @param string $type Type of datasource
+	 * @param array $args Additional datasource args to set
+	 */
+	public function __construct( $type, $args = array() ) {
+
+		$this->type = $type;
+
+		foreach ( $args as $property => $value ) {
+			if ( isset( $this->{$property} ) && is_array( $this->{$property} ) ) {
+				$this->{$property} = array_merge( $this->{$property}, $value );
+			} else {
+				$this->{$property} = $value;
+			}
+		}
+
+	}
+
+	/**
+	 * Setup and return data from the datasource
+	 *
+	 * @param array $args Override datasource args values on-the-fly
+	 * @param WP_Fields_API_Control $control Control object
+	 *
+	 * @return array|WP_Error An array of data, or a WP_Error if there was a problem
+	 */
+	public function get_data( $args = array(), $control = null ) {
+
+		// Allow overriding of $this->get_args values on-the-fly
+		$args = array_merge( $this->get_args, $args );
+
+		// Get data
+		$data = $this->setup_data( $args, $control );
+
+		// @todo Needs hook doc
+		$data = apply_filters( 'fields_api_datasource_data', $data, $this->type, $args, $control, $this );
+
+		// @todo Needs hook doc
+		$data = apply_filters( "fields_api_datasource_data_{$this->type}", $data, $this->type, $args, $control, $this );
+
+		return $data;
+
+	}
+
+	/**
+	 * Get data from the datasource
+	 *
+	 * @param array $args Datasource args
+	 * @param WP_Fields_API_Control $control Control object
+	 *
+	 * @return array|WP_Error An array of data, or a WP_Error if there was a problem
+	 */
+	protected function setup_data( $args, $control ) {
+
+		$data = array();
+
+		// Handle built-in types
+		switch ( $this->type ) {
+
+			case 'post-format':
+				$data = get_post_format_strings();
+
+				break;
+
+			case 'post-type':
+				$data = get_post_types();
+
+				break;
+
+			case 'post-status':
+				$data = get_post_statuses();
+
+				break;
+
+			case 'page-status':
+				$data = get_page_statuses();
+
+				break;
+
+			case 'user-role':
+				$editable_roles = array_reverse( get_editable_roles() );
+
+				foreach ( $editable_roles as $role => $details ) {
+					$name = translate_user_role( $details['name'] );
+
+					$data[ $role ] = $name;
+				}
+
+				break;
+
+		}
+
+		return $data;
+
+	}
+
+	/**
+	 * Allow a datasource to override rendering of a control
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool Whether rendering of control has been overridden
+	 */
+	public function render_control( $control ) {
+
+		return false;
+
+	}
+
+	/**
+	 * Recursively build data array the full depth
+	 *
+	 * @param array $data List of data.
+	 * @param array $items List of items.
+	 * @param int $depth Current depth.
+	 * @param int $parent Current parent item ID.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function setup_data_recurse( $data, $items, $depth = 0, $parent = 0 ) {
+
+		if ( is_wp_error( $items ) ) {
+			return $items;
+		}
+
+		$pad = str_repeat( '&nbsp;', $depth * 3 );
+
+		// Get hierarchical fields for datasource
+		$data_id_field      = $this->hierarchical_fields['id'];
+		$data_parent_field  = $this->hierarchical_fields['parent'];
+		$data_title_field   = $this->hierarchical_fields['title'];
+		$data_default_title = $this->hierarchical_fields['default_title'];
+
+		$data_type = '';
+
+		if ( '' === $data_default_title ) {
+			/* translators: %d: ID of an item */
+			$data_default_title = __( '#%d (no title)' );
+		}
+
+		/**
+		 * @var $item array|object
+		 */
+		foreach ( $items as $item ) {
+			$item_title      = '';
+			$is_hierarchical = $this->hierarchical;
+
+			// Disable hierarchical data if current post type / taxonomy is not hierarchical
+			if ( $is_hierarchical ) {
+				if ( is_a( $item, 'WP_Term' ) ) {
+					if ( $data_type !== $item->taxonomy && ! is_taxonomy_hierarchical( $item->taxonomy ) ) {
+						$is_hierarchical = false;
+					}
+				} elseif ( is_a( $item, 'WP_Post' ) ) {
+					if ( $data_type !== $item->post_type && ! is_post_type_hierarchical( $item->post_type ) ) {
+						$is_hierarchical = false;
+					}
+				}
+			}
+
+			if ( is_object( $item ) && isset( $item->{$data_id_field} ) && isset( $item->{$data_parent_field} ) ) {
+				if ( isset( $item->{$data_title_field} ) ) {
+					$item_title = $item->{$data_title_field};
+				}
+
+				$item_id     = $item->{$data_id_field};
+				$item_parent = $item->{$data_parent_field};
+			} elseif ( is_array( $item ) && isset( $item[ $data_id_field ] ) && isset( $item[ $data_parent_field ] ) ) {
+				if ( isset( $item[ $data_title_field ] ) ) {
+					$item_title = $item[ $data_title_field ];
+				}
+
+				$item_id     = $item[ $data_id_field ];
+				$item_parent = $item[ $data_parent_field ];
+			} else {
+				continue;
+			}
+
+			if ( $is_hierarchical && $parent != $item_parent ) {
+				continue;
+			}
+
+			if ( '' === $item_title ) {
+				$item_title = sprintf( $data_default_title, $item_id );
+			}
+
+			$data[ $item_id ] = $pad . $item_title;
+
+			if ( $is_hierarchical ) {
+				$data = $this->setup_data_recurse( $data, $items, $depth + 1, $item_id );
+			}
+		}
+
+		return $data;
+
+	}
+
+}

--- a/class-wp-fields-api-field.php
+++ b/class-wp-fields-api-field.php
@@ -1,0 +1,663 @@
+<?php
+
+/**
+ * Fields API Field Class
+ *
+ * Handles saving and sanitizing of fields.
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+class WP_Fields_API_Field extends WP_Fields_API_Component {
+
+	/**
+	 * Field type
+	 *
+	 * @var string
+	 */
+	public $type = 'text';
+
+	/**
+	 * Default value for field
+	 *
+	 * @var string
+	 */
+	public $default = '';
+
+	/**
+	 * Server-side sanitization callback for the field's value.
+	 *
+	 * @var callback
+	 */
+	public $sanitize_callback;
+	public $sanitize_js_callback;
+
+	protected $id_data = array();
+
+	/**
+	 * register_meta Auth Callback.
+	 *
+	 * @access public
+	 *
+	 * @see register_meta
+	 *
+	 * @var callable
+	 */
+	public $meta_auth_callback;
+
+	/**
+	 * Whether to show field in REST API.
+	 *
+	 * @access public
+	 *
+	 * @see register_meta
+	 *
+	 * @var bool
+	 */
+	public $show_in_rest = false;
+
+	/**
+	 * Whether to render this field in forms.
+	 *
+	 * @access public
+	 * @var boolean
+	 */
+	public $can_render = false;
+
+	/**
+	 * Value Callback.
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Field::value()
+	 *
+	 * @var callable Callback is called with two arguments, the item ID and the instance of
+	 *               WP_Fields_API_Field. It returns a string for the value to use.
+	 */
+	public $value_callback;
+
+	/**
+	 * Update Value Callback.
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Field::update()
+	 *
+	 * @var callable Callback is called with three arguments, the value being saved, the item ID, and the instance of
+	 *               WP_Fields_API_Field.
+	 */
+	public $update_value_callback;
+
+	/**
+	 * Whether or not a field is
+	 *
+	 * @access public
+	 *
+	 * @var bool
+	 */
+	public $internal = false;
+
+	/**
+	 * Check user capabilities and theme supports, and then save
+	 * the value of the field.
+	 *
+	 * @param mixed $value The value to save.
+	 * @param int|null $item_id The Item ID.
+	 * @param boolean $sanitize Sanitize value before saving
+	 *
+	 * @return false|mixed False if cap check fails or value isn't set.
+	 */
+	public function save( $value, $item_id = null, $sanitize = false ) {
+
+		if ( null === $item_id ) {
+			$item_id = $this->get_item_id();
+		}
+
+		if ( ! $this->check_capabilities() || false === $value ) {
+			return false;
+		}
+
+		if ( $sanitize ) {
+			$value = $this->sanitize( $value );
+
+			if ( is_wp_error( $value ) ) {
+				return $value;
+			}
+		}
+
+		/**
+		 * Fires when the WP_Fields_API_Field::save() method is called.
+		 *
+		 * The dynamic portion of the hook name, `$this->id_data['base']` refers to
+		 * the base slug of the field name.
+		 *
+		 * @param mixed $value The value being saved.
+		 * @param int $item_id The item ID.
+		 * @param WP_Fields_API_Field $this {@see WP_Fields_API_Field} instance.
+		 *
+		 * @return string The value to save
+		 */
+		$value = apply_filters( 'field_save_' . $this->object_type . '_' . $this->id_data['base'], $value, $item_id, $this );
+
+		return $this->update( $value, $item_id );
+
+	}
+
+	/**
+	 * Sanitize an input.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 *
+	 * @return mixed Null if an input isn't valid, otherwise the sanitized value.
+	 */
+	public function sanitize( $value ) {
+
+		$value = wp_unslash( $value );
+
+		if ( is_callable( $this->sanitize_callback ) ) {
+			$value = call_user_func( $this->sanitize_callback, $value, $this );
+		}
+
+		/**
+		 * Filter a Customize field value in un-slashed form.
+		 *
+		 * @param mixed $value Value of the field.
+		 * @param WP_Fields_API_Field $this WP_Fields_API_Field instance.
+		 */
+		return apply_filters( "fields_sanitize_{$this->object_type}_{$this->object_subtype}_{$this->id}", $value, $this );
+
+	}
+
+	/**
+	 * Save the value of the field, using the related API.
+	 *
+	 * @param mixed $value The value to update.
+	 *
+	 * @return mixed The result of saving the value.
+	 */
+	protected function update( $value ) {
+
+		// @todo Support post / term / user / comment object field updates
+
+		$item_id = func_get_arg( 1 );
+
+		switch ( $this->object_type ) {
+			case is_callable( $this->update_value_callback ) :
+				return call_user_func( $this->update_value_callback, $value, $item_id, $this );
+
+			case 'customizer' :
+				return $this->_update_theme_mod( $value );
+
+			case 'settings' :
+				return $this->_update_option( $value );
+
+			case 'post' :
+			case 'term' :
+			case 'user' :
+			case 'comment' :
+				return $this->_update_meta( $this->object_type, $value, $item_id );
+
+			default :
+
+				/**
+				 * Fires when the {@see WP_Fields_API_Field::update()} method is called for fields
+				 * not handled as theme_mods or options.
+				 *
+				 * The dynamic portion of the hook name, `$this->object_type`, refers to the type of field.
+				 *
+				 * @param mixed $value Value of the field.
+				 * @param int $item_id Item ID.
+				 * @param WP_Fields_API_Field $this WP_Fields_API_Field instance.
+				 */
+				do_action( "fields_update_{$this->object_type}", $value, $item_id, $this );
+		}
+
+		return null;
+
+	}
+
+	/**
+	 * Update the theme mod from the value of the parameter.
+	 *
+	 * @param mixed $value The value to update.
+	 *
+	 * @return null
+	 */
+	protected function _update_theme_mod( $value ) {
+
+		if ( is_null( $value ) ) {
+			remove_theme_mod( $this->id_data['base'] );
+		}
+
+		// Handle non-array theme mod.
+		if ( empty( $this->id_data['keys'] ) ) {
+			set_theme_mod( $this->id_data['base'], $value );
+		} else {
+			// Handle array-based theme mod.
+			$mods = get_theme_mod( $this->id_data['base'] );
+			$mods = $this->multidimensional_replace( $mods, $this->id_data['keys'], $value );
+
+			if ( isset( $mods ) ) {
+				set_theme_mod( $this->id_data['base'], $mods );
+			}
+		}
+
+		return null;
+
+	}
+
+	/**
+	 * Update the option from the value of the field.
+	 *
+	 * @param mixed $value The value to update.
+	 *
+	 * @return bool|null The result of saving the value.
+	 */
+	protected function _update_option( $value ) {
+
+		if ( is_null( $value ) ) {
+			delete_option( $this->id_data['base'] );
+		}
+
+		// Handle non-array option.
+		if ( empty( $this->id_data['keys'] ) ) {
+			return update_option( $this->id_data['base'], $value );
+		}
+
+		// Handle array-based options.
+		$options = get_option( $this->id_data['base'] );
+		$options = $this->multidimensional_replace( $options, $this->id_data['keys'], $value );
+
+		if ( isset( $options ) ) {
+			return update_option( $this->id_data['base'], $options );
+		}
+
+		return null;
+
+	}
+
+	/**
+	 * Update the meta from the value of the field.
+	 *
+	 * @param string $meta_type The meta type.
+	 * @param mixed $value The value to update.
+	 * @param int $item_id Item ID.
+	 *
+	 * @return bool|null The result of saving the value.
+	 */
+	protected function _update_meta( $meta_type, $value, $item_id = 0 ) {
+
+		if ( is_null( $value ) ) {
+			delete_metadata( $meta_type, $item_id, $this->id_data['base'] );
+		}
+
+		// Handle non-array option.
+		if ( empty( $this->id_data['keys'] ) ) {
+			return update_metadata( $meta_type, $item_id, $this->id_data['base'], $value );
+		}
+
+		// Handle array-based keys.
+		$keys = get_metadata( $meta_type, 0, $this->id_data['base'] );
+		$keys = $this->multidimensional_replace( $keys, $this->id_data['keys'], $value );
+
+		if ( isset( $keys ) ) {
+			return update_metadata( $meta_type, $item_id, $this->id_data['base'], $keys );
+		}
+
+		return null;
+
+	}
+
+	/**
+	 * Fetch the value of the field.
+	 *
+	 * @return mixed The value.
+	 */
+	public function value() {
+
+		$item_id = func_get_arg( 0 );
+
+		switch ( $this->object_type ) {
+			case is_callable( $this->value_callback ) :
+				$value = call_user_func( $this->value_callback, $item_id, $this );
+				$value = $this->multidimensional_get( $value, $this->id_data['keys'], $this->default );
+
+				break;
+			case 'post' :
+			case 'term' :
+			case 'user' :
+			case 'comment' :
+				$value = $this->get_object_value( $item_id );
+				$value = $this->multidimensional_get( $value, $this->id_data['keys'], $this->default );
+				break;
+
+			case 'customizer' :
+			case 'settings' :
+				$value = $this->get_option_value();
+				$value = $this->multidimensional_get( $value, $this->id_data['keys'], $this->default );
+				break;
+
+			default :
+				/**
+				 * Filter a field value for a custom object type.
+				 *
+				 * The dynamic portion of the hook name, `$this->id_date['base']`, refers to
+				 * the base slug of the field name.
+				 *
+				 * For fields handled as theme_mods, options, or object fields, see those corresponding
+				 * functions for available hooks.
+				 *
+				 * @param mixed $default The field default value. Default empty.
+				 * @param int $item_id (optional) The Item ID.
+				 */
+				$value = apply_filters( 'fields_value_' . $this->object_type . '_' . $this->object_subtype . '_' . $this->id_data['base'], $this->default, $item_id );
+
+				/**
+				 * Fires when the {@see WP_Fields_API_Field::value()} method is called for fields
+				 * not handled as theme_mods or options.
+				 *
+				 * The dynamic portion of the hook name, `$this->object_type`, refers to the type of field.
+				 *
+				 * @param mixed $value Default value of the field.
+				 * @param int $item_id Item ID.
+				 * @param WP_Fields_API_Field $this WP_Fields_API_Field instance.
+				 */
+				$value = apply_filters( "fields_value_{$this->object_type}", $value, $item_id, $this );
+
+				break;
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Get value from meta / object
+	 *
+	 * @param int $item_id
+	 *
+	 * @return mixed|null
+	 */
+	public function get_object_value( $item_id ) {
+
+		$value  = null;
+		$object = null;
+
+		$field_key = $this->id_data['base'];
+
+		switch ( $this->object_type ) {
+			case 'post' :
+				$object = get_post( $item_id );
+				break;
+
+			case 'term' :
+				$object = get_term( $item_id );
+				break;
+
+			case 'user' :
+				$object = get_userdata( $item_id );
+				break;
+
+			case 'comment' :
+				$object = get_comment( $item_id );
+				break;
+		}
+
+		if ( $object && ! is_wp_error( $object ) && isset( $object->{$field_key} ) ) {
+			// Get value from object
+			$value = $object->{$field_key};
+		} else {
+			// Get value from meta
+			$value = get_metadata( $this->object_type, $item_id, $field_key );
+
+			if ( array() === $value ) {
+				$value = $this->default;
+			}
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Get value from option / theme_mod
+	 *
+	 * @return mixed|void
+	 */
+	public function get_option_value() {
+
+		$function = '';
+		$value    = null;
+
+		switch ( $this->object_type ) {
+			case 'customizer' :
+				$function = 'get_theme_mod';
+				break;
+
+			case 'settings' :
+				$function = 'get_option';
+				break;
+		}
+
+		if ( is_callable( $function ) ) {
+			// Handle non-array value
+			if ( empty( $this->id_data['keys'] ) ) {
+				return $function( $this->id_data['base'], $this->default );
+			}
+
+			// Handle array-based value
+			$value = $function( $this->id_data['base'] );
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Sanitize the field's value for use in JavaScript.
+	 *
+	 * @return mixed The requested escaped value.
+	 */
+	public function js_value() {
+
+		$value = $this->value();
+
+		if ( is_callable( $this->sanitize_js_callback ) ) {
+			$value = call_user_func( $this->sanitize_js_callback, $value, $this );
+		}
+
+		/**
+		 * Filter a Customize field value for use in JavaScript.
+		 *
+		 * The dynamic portion of the hook name, `$this->id`, refers to the field ID.
+		 *
+		 * @param mixed $value The field value.
+		 * @param WP_Fields_API_Field $this {@see WP_Fields_API_Field} instance.
+		 */
+		$value = apply_filters( "fields_sanitize_js_{$this->object_type}_{$this->object_subtype}_{$this->id}", $value, $this );
+
+		if ( is_string( $value ) ) {
+			return html_entity_decode( $value, ENT_QUOTES, 'UTF-8' );
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Validate user capabilities whether the theme supports the field.
+	 *
+	 * @return bool False if theme doesn't support the section or user can't change section, otherwise true.
+	 */
+	public function check_capabilities() {
+
+		if ( $this->capability && ! call_user_func_array( 'current_user_can', (array) $this->capability ) ) {
+			return false;
+		}
+
+		if ( $this->theme_supports && ! call_user_func_array( 'current_theme_supports', (array) $this->theme_supports ) ) {
+			return false;
+		}
+
+		$access = true;
+
+		if ( is_callable( $this->capabilities_callback ) ) {
+			$access = call_user_func( $this->capabilities_callback, $this );
+		}
+
+		return $access;
+
+	}
+
+	/**
+	 * Multidimensional helper function.
+	 *
+	 * @param      $root
+	 * @param      $keys
+	 * @param bool $create Default is false.
+	 *
+	 * @return null|array Keys are 'root', 'node', and 'key'.
+	 */
+	final protected function multidimensional( &$root, $keys, $create = false ) {
+
+		if ( $create && empty( $root ) ) {
+			$root = array();
+		}
+
+		if ( ! isset( $root ) || empty( $keys ) ) {
+			return null;
+		}
+
+		$last = array_pop( $keys );
+		$node = &$root;
+
+		foreach ( $keys as $key ) {
+			if ( $create && ! isset( $node[ $key ] ) ) {
+				$node[ $key ] = array();
+			}
+
+			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {
+				return null;
+			}
+
+			$node = &$node[ $key ];
+		}
+
+		if ( $create ) {
+			if ( ! is_array( $node ) ) {
+				// account for an array overriding a string or object value
+				$node = array();
+			}
+			if ( ! isset( $node[ $last ] ) ) {
+				$node[ $last ] = array();
+			}
+		}
+
+		if ( ! isset( $node[ $last ] ) ) {
+			return null;
+		}
+
+		return array(
+			'root' => &$root,
+			'node' => &$node,
+			'key'  => $last,
+		);
+
+	}
+
+	/**
+	 * Will attempt to replace a specific value in a multidimensional array.
+	 *
+	 * @param string $root
+	 * @param array $keys
+	 * @param mixed $value The value to update.
+	 *
+	 * @return string
+	 */
+	final protected function multidimensional_replace( $root, $keys, $value ) {
+
+		if ( ! isset( $value ) ) {
+			return $root;
+		} elseif ( empty( $keys ) ) {
+			// If there are no keys, we're replacing the root.
+			return $value;
+		}
+
+		$result = $this->multidimensional( $root, $keys, true );
+
+		if ( isset( $result ) ) {
+			$result['node'][ $result['key'] ] = $value;
+		}
+
+		return $root;
+
+	}
+
+	/**
+	 * Will attempt to fetch a specific value from a multidimensional array.
+	 *
+	 * @param       $root
+	 * @param       $keys
+	 * @param mixed $default A default value which is used as a fallback. Default is null.
+	 *
+	 * @return mixed The requested value or the default value.
+	 */
+	final protected function multidimensional_get( $root, $keys, $default = null ) {
+
+		// If there are no keys, test the root.
+		if ( empty( $keys ) ) {
+			if ( isset( $root ) ) {
+				return $root;
+			}
+		} else {
+			$result = $this->multidimensional( $root, $keys );
+
+			if ( isset( $result ) ) {
+				return $result['node'][ $result['key'] ];
+			}
+		}
+
+		return $default;
+
+	}
+
+	/**
+	 * Will attempt to check if a specific value in a multidimensional array is set.
+	 *
+	 * @param $root
+	 * @param $keys
+	 *
+	 * @return bool True if value is set, false if not.
+	 */
+	final protected function multidimensional_isset( $root, $keys ) {
+
+		$result = $this->multidimensional_get( $root, $keys );
+
+		return isset( $result );
+
+	}
+}
+
+/**
+ * A field that is used to filter a value, but will not save the results.
+ *
+ * Results should be properly handled using another field or callback.
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+class WP_Fields_API_Filter_Field extends WP_Fields_API_Field {
+
+	/**
+	 * Save the value of the field, using the related API.
+	 *
+	 * @param mixed $value The value to update.
+	 *
+	 * @return mixed The result of saving the value.
+	 */
+	public function update( $value ) {
+
+		return null;
+
+	}
+}

--- a/class-wp-fields-api-form.php
+++ b/class-wp-fields-api-form.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * WordPress Fields API Form class
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Form class.
+ *
+ * A UI container for sections, managed by WP_Fields_API.
+ *
+ * @see WP_Fields_API
+ */
+class WP_Fields_API_Form extends WP_Fields_API_Container {
+
+	/**
+	 * Object type.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $object_type;
+
+	/**
+	 * Default section type to use for new sections added to form
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $default_section_type = 'table';
+
+	/**
+	 * Container children type
+	 *
+	 * @var string
+	 */
+	public $container_type = 'form';
+
+	/**
+	 * Container children type
+	 *
+	 * @var string
+	 */
+	public $child_container_type = 'section';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct( $id, $args = array() ) {
+
+		$sections = array();
+
+		if ( isset( $args['sections'] ) ) {
+			if ( ! empty( $args['sections'] ) && is_array( $args['sections'] ) ) {
+				$sections = $args['sections'];
+			}
+
+			unset( $args['sections'] );
+		}
+
+		parent::__construct( $id, $args );
+
+		foreach ( $sections as $section_id => $section ) {
+			$this->add_section( $section_id, $section );
+		}
+
+	}
+
+	/**
+	 * Add a section
+	 *
+	 * @param string $id Section ID
+	 * @param array|WP_Fields_API_Section $args Section arguments
+	 *
+	 * @return WP_Error|WP_Fields_API_Section
+	 */
+	public function add_section( $id, $args = array() ) {
+
+		if ( is_a( $args, 'WP_Fields_API_Section' ) ) {
+			$id = $args->id;
+		} elseif ( ! is_array( $args ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-unexpected-arguments', __( 'Unexpected arguments.', 'fields-api' ) );
+		} elseif ( ! empty( $args['id'] ) ) {
+			$id = $args['id'];
+
+			unset( $args['id'] );
+		}
+
+		return $this->add_child( $id, $args );
+
+	}
+
+	/**
+	 * Get a section
+	 *
+	 * @param string $id Section ID
+	 *
+	 * @return WP_Fields_API_Section|false
+	 */
+	public function get_section( $id ) {
+
+		return $this->get_child( $id );
+
+	}
+
+	/**
+	 * Remove a section
+	 *
+	 * @param string $id Section ID
+	 */
+	public function remove_section( $id ) {
+
+		$this->remove_child( $id );
+
+	}
+
+	/**
+	 * Handle saving of fields
+	 *
+	 * @param int|null $item_id Item ID
+	 * @param string|null $object_subtype Object subtype
+	 *
+	 * @return bool|array false if saving doesn't occur, true if there are no errors, array if there are error(s)
+	 */
+	public function save_fields( $item_id = null, $object_subtype = null ) {
+
+		if ( ! empty( $item_id ) ) {
+			$this->item_id = $item_id;
+		}
+
+		if ( ! empty( $object_subtype ) ) {
+			$this->object_subtype = $object_subtype;
+		}
+
+		$form_nonce = $this->object_type . '_' . $this->id;
+
+		if ( ! empty( $_REQUEST['wp_fields_api_fields_save'] ) && false !== wp_verify_nonce( $_REQUEST['wp_fields_api_fields_save'], $form_nonce ) ) {
+			$values = array();
+
+			/**
+			 * @var $sections WP_Fields_API_Section[]
+			 */
+			$sections = $this->get_children();
+
+			$errors = array();
+
+			foreach ( $sections as $section ) {
+				if ( ! $section->check_capabilities() ) {
+					continue;
+				}
+
+				/**
+				 * @var $controls WP_Fields_API_Control[]
+				 */
+				$controls = $section->get_children();
+
+				// Get values, handle validation first
+				foreach ( $controls as $control ) {
+					if ( ! $control->check_capabilities() ) {
+						continue;
+					}
+
+					if ( $control->internal && 'readonly' !== $control->type ) {
+						continue;
+					}
+
+					$field = $control->field;
+
+					if ( ! $field ) {
+						continue;
+					}
+
+					// Pass $object_subtype into control
+					$control->object_subtype = $this->object_subtype;
+
+					// Pass $object_subtype into field
+					$field->object_subtype = $this->object_subtype;
+
+					// Get value from $_POST
+					$value = null;
+
+					$input_attrs = $control->get_input_attrs();
+					$input_name  = $input_attrs['name'];
+
+					if ( ! empty( $_POST[ $input_name ] ) ) {
+						$value = $_POST[ $input_name ];
+					}
+
+					// Sanitize
+					$value = $field->sanitize( $value );
+
+					if ( is_wp_error( $value ) ) {
+						$control->error       = $value;
+						$errors[ $field->id ] = $value;
+					} else {
+						$values[ $field->id ] = $value;
+					}
+				}
+
+				/**
+				 * Allow user to short circuit all saving if an error occurs
+				 */
+				if ( apply_filters( 'wp_fields_api_skip_save_on_error', false, $this, $errors, $values ) ) {
+					return $errors;
+				}
+
+				// Save values once validation completes
+				foreach ( $controls as $control ) {
+					if ( $control->internal && 'readonly' !== $control->type ) {
+						continue;
+					}
+
+					$field = $control->field;
+
+					if ( ! $field || ! isset( $values[ $field->id ] ) ) {
+						continue;
+					}
+
+					$value = $values[ $field->id ];
+
+					// Save value
+					$success = $field->save( $value, $item_id );
+
+					if ( is_wp_error( $success ) ) {
+						$errors[ $field->id ] = $success;
+					}
+				}
+			}
+
+			if ( ! empty( $errors ) ) {
+				return $errors;
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Render form for implementation
+	 */
+	protected function render() {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		$form_nonce = $this->object_type . '_' . $this->id;
+
+		wp_nonce_field( $form_nonce, 'wp_fields_api_fields_save' );
+
+		$sections = $this->get_children();
+
+		if ( ! empty( $sections ) ) {
+			?>
+            <div class="fields-form-<?php echo esc_attr( $this->get_object_type() ); ?> form-<?php echo esc_attr( $this->id ); ?>-wrap fields-api-form">
+				<?php
+				foreach ( $sections as $section ) {
+					// Pass $object_subtype into section
+					$section->object_subtype = $this->object_subtype;
+
+					$section->maybe_render();
+				}
+				?>
+            </div>
+			<?php
+
+			// Render control templates
+			add_action( 'admin_print_footer_scripts', array( $wp_fields, 'render_control_templates' ), 5 );
+		}
+
+	}
+
+}

--- a/class-wp-fields-api-section.php
+++ b/class-wp-fields-api-section.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * WordPress Fields API Section class
+ *
+ * @package WordPress
+ * @subpackage Fields API
+ */
+
+/**
+ * Fields API Section class.
+ *
+ * A UI container for controls, managed by the WP_Fields_API.
+ */
+class WP_Fields_API_Section extends WP_Fields_API_Container {
+
+	/**
+	 * Container type
+	 *
+	 * @var string
+	 */
+	public $container_type = 'section';
+
+	/**
+	 * Container children type
+	 *
+	 * @var string
+	 */
+	public $child_container_type = 'control';
+
+	/**
+	 * Hidden controls
+	 *
+	 * @access protected
+	 * @var WP_Fields_API_Control[]
+	 */
+	protected $hidden_controls = array();
+
+	/**
+	 * Label to render
+	 *
+	 * @var string
+	 */
+	public $label;
+
+	/**
+	 * Show label or not
+	 *
+	 * @var bool
+	 */
+	public $display_label;
+
+	/**
+	 * Description to render
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * Description callback function to execute
+	 *
+	 * @var callback
+	 */
+	public $description_callback;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct( $id, $args = array() ) {
+
+		$controls = array();
+
+		if ( isset( $args['controls'] ) ) {
+			if ( ! empty( $args['controls'] ) && is_array( $args['controls'] ) ) {
+				$controls = $args['controls'];
+			}
+
+			unset( $args['controls'] );
+		}
+
+		parent::__construct( $id, $args );
+
+		foreach ( $controls as $control_id => $control ) {
+			$this->add_control( $control_id, $control );
+		}
+
+	}
+
+	/**
+	 * Add a control
+	 *
+	 * @param string $id Control ID
+	 * @param array|WP_Fields_API_Control $args Control arguments
+	 *
+	 * @return WP_Error|WP_Fields_API_Control
+	 */
+	public function add_control( $id, $args = array() ) {
+
+		if ( is_a( $args, 'WP_Fields_API_Control' ) ) {
+			$id = $args->id;
+		} elseif ( ! is_array( $args ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-unexpected-arguments', __( 'Unexpected arguments.', 'fields-api' ) );
+		} elseif ( ! empty( $args['id'] ) ) {
+			$id = $args['id'];
+
+			unset( $args['id'] );
+		}
+
+		return $this->add_child( $id, $args );
+
+	}
+
+	/**
+	 * Get a control
+	 *
+	 * @param string $id Control ID
+	 *
+	 * @return WP_Fields_API_Control|false
+	 */
+	public function get_control( $id ) {
+
+		return $this->get_child( $id );
+
+	}
+
+	/**
+	 * Remove a control
+	 *
+	 * @param string $id Control ID
+	 */
+	public function remove_control( $id ) {
+
+		$this->remove_child( $id );
+
+	}
+
+	/**
+	 * Render the section, and the controls that have been added to it.
+	 */
+	protected function render() {
+
+		?>
+        <div class="fields-form-<?php echo esc_attr( $this->get_object_type() ); ?>-section section-<?php echo esc_attr( $this->id ); ?>-wrap fields-api-section">
+			<?php
+			if ( $this->label && $this->display_label ) {
+				?>
+                <h3><?php $this->render_label(); ?></h3>
+				<?php
+			}
+
+			$this->render_description();
+
+			$this->render_controls();
+			$this->render_hidden_controls();
+
+			/**
+			 * Fires after rendering Fields API section.
+			 *
+			 * @param WP_Fields_API_Section $this WP_Fields_API_Section instance.
+			 */
+			do_action( "fields_after_render_section_{$this->object_type}", $this );
+
+			/**
+			 * Fires after rendering Fields API controls for a section.
+			 *
+			 * The dynamic portion of the hook name, `$this->id`, refers to
+			 * the ID of the specific Fields API section rendered.
+			 *
+			 * @param WP_Fields_API_Section $this WP_Fields_API_Section instance.
+			 */
+			do_action( "fields_after_render_section_{$this->object_type}_{$this->id}", $this );
+			?>
+        </div>
+		<?php
+
+	}
+
+	/**
+	 * Render controls for section
+	 */
+	protected function render_controls() {
+
+		$controls = $this->get_children();
+
+		foreach ( $controls as $control ) {
+
+			if ( ! $control->check_capabilities() ) {
+				continue;
+			}
+
+			if ( 'hidden' === $control->type ) {
+				$this->hidden_controls[] = $control;
+
+				continue;
+			}
+
+			$control->maybe_render();
+		}
+
+		/**
+		 * Fires after rendering Fields API controls for a section.
+		 *
+		 * @param WP_Fields_API_Section $this WP_Fields_API_Section instance.
+		 */
+		do_action( "fields_after_render_section_controls_{$this->object_type}", $this );
+
+		/**
+		 * Fires after rendering Fields API controls for a section.
+		 *
+		 * The dynamic portion of the hook name, `$this->id`, refers to
+		 * the ID of the specific Fields API section to have controls rendered.
+		 *
+		 * @param WP_Fields_API_Section $this WP_Fields_API_Section instance.
+		 */
+		do_action( "fields_after_render_section_controls_{$this->object_type}_{$this->id}", $this );
+
+	}
+
+	/**
+	 * Render the container label.
+	 */
+	public function render_label() {
+		if ( $this->label && $this->display_label ) {
+			echo esc_html( $this->label );
+		}
+	}
+
+	/**
+	 * Render hidden controls for section
+	 */
+	protected function render_hidden_controls() {
+
+		$controls = $this->hidden_controls;
+
+		foreach ( $controls as $control ) {
+			$control->maybe_render();
+		}
+
+		$this->hidden_controls = array();
+
+	}
+
+	/**
+	 * Render control wrapper, label, description, and control input
+	 *
+	 * @param WP_Fields_API_Control $control Control object
+	 */
+	protected function render_control( $control ) {
+
+		$input_id = 'field-' . $control->id;
+
+		if ( isset( $control->input_attrs['id'] ) ) {
+			$input_id = $control->input_attrs['id'];
+		}
+		?>
+        <div <?php $control->wrap_attrs(); ?>>
+			<?php if ( $control->label && $control->display_label ) { ?>
+                <label for="<?php echo esc_attr( $input_id ); ?>">
+					<?php $control->render_label(); ?>
+                </label>
+			<?php } ?>
+
+			<?php $control->maybe_render(); ?>
+			<?php $control->render_description(); ?>
+        </div>
+		<?php
+
+	}
+
+	/**
+	 * Remder the container description.
+	 */
+	public function render_description() {
+		if ( is_callable( $this->description_callback ) ) {
+			call_user_func( $this->description_callback, $this );
+
+			return;
+		}
+		if ( $this->description ) {
+			?>
+            <p class="description">
+				<?php echo wp_kses_post( $this->description ); ?>
+            </p>
+			<?php
+		}
+	}
+
+	/**
+	 * Gather the parameters passed to client JavaScript via JSON.
+	 *
+	 * @return array The array to be exported to the client as JSON.
+	 */
+	public function json() {
+
+		$json = array();
+
+		$json['label']       = html_entity_decode( $this->label, ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$json['description'] = wp_kses_post( $this->description );
+
+		$json = array_merge( $json, parent::json() );
+
+		return $json;
+
+	}
+
+}

--- a/class-wp-fields-api.php
+++ b/class-wp-fields-api.php
@@ -1,0 +1,638 @@
+<?php
+
+/**
+ * This is a manager for the Fields API, based on the WP_Customize_Manager.
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+final class WP_Fields_API {
+
+	/**
+	 * Instantiated components
+	 *
+	 * @access protected
+	 * @var array $components {
+	 * @type WP_Fields_API_Form[] $form
+	 * @type WP_Fields_API_Section[] $section
+	 * @type WP_Fields_API_Control[] $control
+	 * @type WP_Fields_API_Field[] $field
+	 * }
+	 */
+	public $components = array(
+		'form'    => array(),
+		'section' => array(),
+		'control' => array(),
+		'field'   => array(),
+	);
+
+	/**
+	 * Form component types that may be rendered.
+	 *
+	 * @access protected
+	 * @var array
+	 */
+	protected $registered_types = array();
+
+	/**
+	 * Include the library and bootstrap.
+	 *
+	 * @constructor
+	 * @access public
+	 */
+	private function __construct() {
+
+		$fields_api_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/';
+
+		// Include API classes
+		require_once( $fields_api_dir . 'class-wp-fields-api-component.php' );
+		require_once( $fields_api_dir . 'class-wp-fields-api-container.php' );
+		require_once( $fields_api_dir . 'class-wp-fields-api-form.php' );
+		require_once( $fields_api_dir . 'class-wp-fields-api-section.php' );
+		require_once( $fields_api_dir . 'class-wp-fields-api-field.php' );
+		require_once( $fields_api_dir . 'class-wp-fields-api-control.php' );
+		require_once( $fields_api_dir . 'class-wp-fields-api-datasource.php' );
+
+		// Include section types
+		require_once( $fields_api_dir . 'section-types/class-wp-fields-api-table-section.php' );
+		require_once( $fields_api_dir . 'section-types/class-wp-fields-api-meta-box-section.php' );
+		require_once( $fields_api_dir . 'section-types/class-wp-fields-api-meta-box-table-section.php' );
+
+		// Include control types
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-readonly-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-textarea-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-wysiwyg-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-checkbox-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-multi-checkbox-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-radio-control.php' );
+		//require_once( $fields_api_dir . 'control-types/class-wp-fields-api-radio-multi-label-control.php' ); // @todo Revisit
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-select-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-color-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-media-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-media-file-control.php' );
+		require_once( $fields_api_dir . 'control-types/class-wp-fields-api-number-inline-description.php' );
+
+		// Include datasources
+		require_once( $fields_api_dir . 'datasources/class-wp-fields-api-admin-color-scheme-datasource.php' );
+		require_once( $fields_api_dir . 'datasources/class-wp-fields-api-comment-datasource.php' );
+		require_once( $fields_api_dir . 'datasources/class-wp-fields-api-post-datasource.php' );
+		require_once( $fields_api_dir . 'datasources/class-wp-fields-api-page-datasource.php' );
+		require_once( $fields_api_dir . 'datasources/class-wp-fields-api-term-datasource.php' );
+		require_once( $fields_api_dir . 'datasources/class-wp-fields-api-user-datasource.php' );
+
+		// Register our wp_loaded() first before WP_Customize_Manage::wp_loaded()
+		add_action( 'wp_loaded', array( $this, 'wp_loaded' ), 9 );
+
+	}
+
+	/**
+	 * Setup instance for singleton
+	 *
+	 * @return WP_Fields_API
+	 */
+	public static function get_instance() {
+		static $instance;
+
+		if ( empty( $instance ) ) {
+			$instance = new self;
+		}
+
+		return $instance;
+
+	}
+
+	/**
+	 * Trigger the `fields_register` action hook on `wp_loaded`.
+	 *
+	 * Fields, Sections, Forms, and Controls should be registered on this hook.
+	 *
+	 * @access public
+	 */
+	public function wp_loaded() {
+
+		// Register default controls
+		$this->register_defaults();
+
+		/**
+		 * Fires when the Fields API is available, and components can be registered.
+		 *
+		 * @param WP_Fields_API $this The Fields manager object.
+		 */
+		do_action( 'fields_register', $this );
+
+	}
+
+	/**
+	 * Get the registered forms.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type.
+	 * @param string $object_subtype Object subtype (for post types and taxonomies).
+	 *
+	 * @return WP_Fields_API_Form[]
+	 */
+	public function get_forms( $object_type = null, $object_subtype = null ) {
+
+		/**
+		 * @var $forms WP_Fields_API_Form[]
+		 */
+		$forms = $this->components['form'];
+
+		if ( $object_type !== null || $object_subtype !== null ) {
+			foreach ( $forms as $key => $form ) {
+				if ( $object_type !== null && $form->get_object_type() !== $object_type ) {
+					unset( $forms[ $key ] );
+				} elseif ( $object_subtype !== null && $form->object_subtype !== $object_subtype ) {
+					unset( $forms[ $key ] );
+				}
+			}
+		}
+
+		return $forms;
+
+	}
+
+	/**
+	 * Get a form
+	 *
+	 * @access public
+	 *
+	 * @param string|WP_Fields_API_Form $id Unique form id
+	 *
+	 * @return WP_Fields_API_Form|false
+	 */
+	public function get_form( $id ) {
+
+		$form = false;
+
+		if ( is_a( $id, 'WP_Fields_API_Form' ) ) {
+			$form = $id;
+		} elseif ( ! empty( $this->components['form'][ $id ] ) ) {
+			$form = $this->components['form'][ $id ];
+		}
+
+		return $form;
+
+	}
+
+	/**
+	 * Create a form
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type.
+	 * @param string $id Unique form id.
+	 * @param array|WP_Fields_API_Form $args Additional form arguments.
+	 *
+	 * @return WP_Error|WP_Fields_API_Form
+	 */
+	public function add_form( $object_type, $id, $args = array() ) {
+
+		if ( empty( $object_type ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-object-type-required', __( 'Object type is required.', 'fields-api' ) );
+		}
+
+		$form = null;
+
+		if ( is_a( $args, 'WP_Fields_API_Form' ) ) {
+			$id   = $args->id;
+			$args = array();
+
+			$form->object_type = $object_type;
+		} elseif ( ! is_array( $args ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-unexpected-arguments', __( 'Unexpected arguments.', 'fields-api' ) );
+		}
+
+		if ( empty( $id ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-id-required', __( 'ID is required.', 'fields-api' ) );
+		}
+
+		if ( ! empty( $this->components['form'][ $id ] ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-id-exists', __( 'ID already exists.', 'fields-api' ) );
+		}
+
+		if ( ! $form ) {
+			$class = $this->get_registered_type( 'form', 'default' );
+
+			if ( ! empty( $args['type'] ) ) {
+				$class = $this->get_registered_type( 'form', $args['type'] );
+			}
+
+			$args['object_type'] = $object_type;
+
+			$form = new $class( $id, $args );
+		}
+
+		$this->components['form'][ $id ] = $form;
+
+		return $this->components['form'][ $id ];
+
+	}
+
+	/**
+	 * Remove a form.
+	 *
+	 * @access public
+	 *
+	 * @param string|WP_Fields_API_Form $form Form ID or object to remove
+	 */
+	public function remove_form( $form ) {
+
+		if ( ! is_a( $form, 'WP_Fields_API_Form' ) ) {
+			$form = $this->get_form( $form );
+		}
+
+		if ( $form && ! empty( $this->components['form'][ $form->id ] ) ) {
+			unset( $this->components['form'][ $form->id ] );
+
+			unset( $form );
+		}
+
+	}
+
+	/**
+	 * Remove all forms
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type
+	 * @param string $object_subtype Object subtype (for post types and taxonomies).
+	 */
+	public function remove_forms( $object_type = null, $object_subtype = null ) {
+		if ( null === $object_type && null === $object_subtype ) {
+			$this->components['form'] = array();
+
+			return;
+		}
+
+		if ( null !== $object_type ) {
+			/**
+			 * @var $form WP_Fields_API_Form
+			 */
+			foreach ( $this->components['form'] as $id => $form ) {
+				if ( $object_type === $form->object_type ) {
+					if ( null === $object_subtype || $object_subtype === $form->object_subtype ) {
+						unset( $this->components['form'][ $id ] );
+
+						unset( $form );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get a field from a form
+	 *
+	 * @param string $object_type Object type
+	 * @param string|WP_Fields_API_Field $id Field ID to get.
+	 *
+	 * @return WP_Fields_API_Field|bool Requested section instance.
+	 */
+	public function get_field( $object_type, $id ) {
+
+		$field = false;
+
+		if ( is_a( $id, 'WP_Fields_API_Field' ) ) {
+			$field = $id;
+		} elseif ( ! empty( $this->components['field'][ $object_type ][ $id ] ) ) {
+			$field = $this->components['field'][ $object_type ][ $id ];
+		}
+
+		return $field;
+
+	}
+
+	/**
+	 * Add a field.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type
+	 * @param string $id Fields API Field object, or ID.
+	 * @param array $args Field arguments; passed to WP_Fields_API_Field constructor.
+	 *
+	 * @return WP_Fields_API_Field|WP_Error
+	 */
+	public function add_field( $object_type, $id, $args = array() ) {
+
+		if ( empty( $object_type ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-object-type-required', __( 'Object type is required.', 'fields-api' ) );
+		}
+
+		$field = null;
+
+		if ( is_a( $args, 'WP_Fields_API_Field' ) ) {
+			$id   = $args->id;
+			$args = array();
+
+			$field->object_type = $object_type;
+		} elseif ( ! is_array( $args ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-unexpected-arguments', __( 'Unexpected arguments.', 'fields-api' ) );
+		}
+
+		if ( empty( $id ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-id-required', __( 'ID is required.', 'fields-api' ) );
+		}
+
+		if ( ! empty( $this->components['field'][ $object_type ][ $id ] ) ) {
+			// @todo Need WP_Error code
+			return new WP_Error( 'fields-api-id-exists', __( 'ID already exists.', 'fields-api' ) );
+		}
+
+		if ( ! $field ) {
+			$class = $this->get_registered_type( 'field', 'default' );
+
+			if ( ! empty( $args['type'] ) ) {
+				$class = $this->get_registered_type( 'field', $args['type'] );
+			}
+
+			$args['object_type'] = $object_type;
+
+			$field = new $class( $id, $args );
+		}
+
+		$this->components['field'][ $object_type ][ $id ] = $field;
+
+		return $this->components['field'][ $object_type ][ $id ];
+
+	}
+
+	/**
+	 * Remove a field
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type
+	 * @param string|WP_Fields_API_Field $field Field ID or object to remove
+	 */
+	public function remove_field( $object_type, $field ) {
+
+		if ( ! is_a( $field, 'WP_Fields_API_Field' ) ) {
+			$field = $this->get_field( $object_type, $field );
+		}
+
+		if ( $field ) {
+			if ( ! empty( $field->parent ) ) {
+				/**
+				 * @var $parent WP_Fields_API_Control
+				 */
+				$parent = $field->parent;
+
+				$parent->remove_field();
+			}
+
+			if ( ! empty( $this->components['field'][ $object_type ][ $field->id ] ) ) {
+				unset( $this->components['field'][ $object_type ][ $field->id ] );
+			}
+
+			unset( $field );
+		}
+
+	}
+
+	/**
+	 * Get all registered types
+	 *
+	 * @access public
+	 *
+	 * @return array
+	 */
+	public function get_registered_types() {
+		return $this->registered_types;
+	}
+
+	/**
+	 * Get all registered types
+	 *
+	 * @access public
+	 *
+	 * @param string $component_type Component type
+	 * @param string $type Registered type
+	 *
+	 * @return string|null
+	 */
+	public function get_registered_type( $component_type, $type ) {
+
+		$class = null;
+
+		if ( ! empty( $this->registered_types[ $component_type ] ) ) {
+			if ( ! empty( $this->registered_types[ $component_type ][ $type ] ) ) {
+				$class = $this->registered_types[ $component_type ][ $type ];
+			} elseif ( ! empty( $this->registered_types[ $component_type ]['default'] ) ) {
+				$class = $this->registered_types[ $component_type ]['default'];
+			}
+		}
+
+		return $class;
+
+	}
+
+	/**
+	 * Register a form type.
+	 *
+	 * @access public
+	 *
+	 * @param string $type Form type ID.
+	 * @param string $form_class Name of a custom form which is a subclass of WP_Fields_API_Form.
+	 *
+	 * @see    WP_Fields_API_Form
+	 *
+	 */
+	public function register_form_type( $type, $form_class = 'WP_Fields_API_Form' ) {
+		$this->registered_types['form'][ $type ] = $form_class;
+	}
+
+	/**
+	 * Register a section type for use later
+	 *
+	 * @access public
+	 *
+	 * @param string $type Type slug
+	 * @param string $section_class Name of a custom section which is a subclass of WP_Fields_API_Section.
+	 */
+	public function register_section_type( $type, $section_class = 'WP_Fields_API_Section' ) {
+		$this->registered_types['section'][ $type ] = $section_class;
+	}
+
+	/**
+	 * Register a control type for use later
+	 *
+	 * @access public
+	 *
+	 * @param string $type Type slug
+	 * @param string $control_class Name of a custom form which is a subclass of WP_Fields_API_Control.
+	 */
+	public function register_control_type( $type, $control_class = 'WP_Fields_API_Control' ) {
+		$this->registered_types['control'][ $type ] = $control_class;
+	}
+
+	/**
+	 * Register a field type.
+	 *
+	 * @access public
+	 *
+	 * @param string $type Field type ID.
+	 * @param string $field_class Name of a custom field type which is a subclass of WP_Fields_API_Field.
+	 *
+	 * @see    WP_Fields_API_Field
+	 *
+	 */
+	public function register_field_type( $type, $field_class = 'WP_Fields_API_Field' ) {
+		$this->registered_types['field'][ $type ] = $field_class;
+	}
+
+	/**
+	 * Register a datasource type for use later
+	 *
+	 * @access public
+	 *
+	 * @param string $type Type slug
+	 * @param string $datasource_class Name of a custom datasource which is a subclass of WP_Fields_API_Datasource.
+	 */
+	public function register_datasource_type( $type, $datasource_class = 'WP_Fields_API_Datasource' ) {
+		$this->registered_types['datasource'][ $type ] = $datasource_class;
+	}
+
+	/**
+	 * Register some default form and control types.
+	 *
+	 * @access public
+	 */
+	public function register_defaults() {
+		/* Defaults */
+		$this->register_form_type( 'default', 'WP_Fields_API_Form' );
+		$this->register_section_type( 'default', 'WP_Fields_API_Section' );
+		$this->register_control_type( 'default', 'WP_Fields_API_Control' );
+		$this->register_field_type( 'default', 'WP_Fields_API_Field' );
+		$this->register_datasource_type( 'default', 'WP_Fields_API_Datasource' );
+
+		/* Section Types */
+		$this->register_section_type( 'meta-box', 'WP_Fields_API_Meta_Box_Section' );
+		$this->register_section_type( 'meta-box-table', 'WP_Fields_API_Meta_Box_Table_Section' );
+		$this->register_section_type( 'table', 'WP_Fields_API_Table_Section' );
+
+		/* Control Types */
+		$this->register_control_type( 'text', 'WP_Fields_API_Control' );
+		$this->register_control_type( 'number', 'WP_Fields_API_Control' );
+		$this->register_control_type( 'email', 'WP_Fields_API_Control' );
+		$this->register_control_type( 'password', 'WP_Fields_API_Control' );
+		$this->register_control_type( 'hidden', 'WP_Fields_API_Control' );
+		$this->register_control_type( 'readonly', 'WP_Fields_API_Readonly_Control' );
+		$this->register_control_type( 'textarea', 'WP_Fields_API_Textarea_Control' );
+		$this->register_control_type( 'wysiwyg', 'WP_Fields_API_WYSIWYG_Control' );
+		$this->register_control_type( 'checkbox', 'WP_Fields_API_Checkbox_Control' );
+		$this->register_control_type( 'multi-checkbox', 'WP_Fields_API_Multi_Checkbox_Control' );
+		$this->register_control_type( 'radio', 'WP_Fields_API_Radio_Control' );
+		//$this->register_control_type( 'radio-multi-label', 'WP_Fields_API_Radio_Multi_Label_Control' ); // @todo Revisit
+		$this->register_control_type( 'select', 'WP_Fields_API_Select_Control' );
+		$this->register_control_type( 'color', 'WP_Fields_API_Color_Control' );
+		$this->register_control_type( 'media', 'WP_Fields_API_Media_Control' );
+		$this->register_control_type( 'media-file', 'WP_Fields_API_Media_File_Control' );
+		$this->register_control_type( 'number-inline-desc', 'WP_Fields_API_Number_Inline_Description_Control' ); // @todo Revisit
+
+		/* Datasources */
+		$this->register_datasource_type( 'post-format', 'WP_Fields_API_Datasource' );
+		$this->register_datasource_type( 'post-type', 'WP_Fields_API_Datasource' );
+		$this->register_datasource_type( 'post-status', 'WP_Fields_API_Datasource' );
+		$this->register_datasource_type( 'page-status', 'WP_Fields_API_Datasource' );
+		$this->register_datasource_type( 'user-role', 'WP_Fields_API_Datasource' );
+		$this->register_datasource_type( 'admin-color-scheme', 'WP_Fields_API_Admin_Color_Scheme_Datasource' );
+		$this->register_datasource_type( 'comment', 'WP_Fields_API_Comment_Datasource' );
+		$this->register_datasource_type( 'post', 'WP_Fields_API_Post_Datasource' );
+		$this->register_datasource_type( 'page', 'WP_Fields_API_Page_Datasource' );
+		$this->register_datasource_type( 'term', 'WP_Fields_API_Term_Datasource' );
+		$this->register_datasource_type( 'user', 'WP_Fields_API_User_Datasource' );
+
+		/**
+		 * Fires once WordPress has loaded, allowing control types to be registered.
+		 *
+		 * @param WP_Fields_API $this WP_Fields_API instance.
+		 */
+		do_action( 'fields_register_controls', $this );
+
+	}
+
+	/**
+	 * Register meta integration for register_meta and REST API
+	 *
+	 * @param string $object_type Object type
+	 * @param string $id Field ID
+	 * @param array|WP_Fields_API_Field $field Field object or options array
+	 * @param string|null $object_subtype Object subtype
+	 */
+	public function register_meta_integration( $object_type, $id, $field, $object_subtype = null ) {
+
+		// Meta types call register_meta() and register_rest_field() for their fields
+		if ( in_array( $object_type, array(
+				'post',
+				'term',
+				'user',
+				'comment'
+			) ) && ! $field->internal
+		) {
+			// Set callbacks
+			$args = array(
+				'sanitize_callback' => array( $this, 'register_meta_sanitize_callback' ),
+				'auth_callback'     => $field->meta_auth_callback,
+				'show_in_rest'      => $field->show_in_rest,
+			);
+
+			register_meta( $object_type, $id, $args );
+		}
+
+	}
+
+	/**
+	 * Hook into register_meta() sanitize callback and call field
+	 *
+	 * @param mixed $meta_value Meta value to sanitize.
+	 * @param string $meta_key Meta key.
+	 * @param string $meta_type Meta type.
+	 *
+	 * @return mixed
+	 */
+	public function register_meta_sanitize_callback( $meta_value, $meta_key, $meta_type ) {
+
+		// @todo Fix
+		$field = $this->get_field( $meta_type, $meta_key );
+
+		if ( $field ) {
+			$meta_value = $field->sanitize( $meta_value );
+		}
+
+		return $meta_value;
+
+	}
+
+	/**
+	 * Get argument from field array or object
+	 *
+	 * @param array|object $field
+	 * @param string $arg
+	 *
+	 * @return null|mixed
+	 */
+	public function get_field_arg( $field, $arg ) {
+
+		$value = null;
+
+		if ( is_array( $field ) && isset( $field[ $arg ] ) ) {
+			$value = $field[ $arg ];
+		} elseif ( is_object( $field ) && isset( $field->{$arg} ) ) {
+			$value = $field->{$arg};
+		}
+
+		return $value;
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-checkbox-control.php
+++ b/control-types/class-wp-fields-api-checkbox-control.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Checkbox Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Checkbox_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'checkbox';
+
+	/**
+	 * Checkbox label used for the <input> label
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Checkbox_Control::render_checkbox_label()
+	 *
+	 * @var string
+	 */
+	public $checkbox_label;
+
+	/**
+	 * Checkbox value, allowing for separation of value, 'default' value, and checkbox value.
+	 *
+	 * @access public
+	 *
+	 * @see WP_Fields_API_Checkbox_Control::checkbox_value()
+	 *
+	 * @var string
+	 */
+	public $checkbox_value;
+
+	/**
+	 * Render checkbox label
+	 */
+	protected function render_checkbox_label() {
+
+		$label = '';
+
+		if ( $this->checkbox_label ) {
+			$label = $this->checkbox_label;
+		}
+
+		if ( $label && $this->display_label ) {
+			echo wp_kses( $label, array(
+				'a' => array(
+					'href' => true,
+				),
+			) );
+		}
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		$checkbox_value = $this->checkbox_value();
+		$value          = $this->value();
+
+		$checked = false;
+
+		if ( '' !== $value && $checkbox_value == $value ) {
+			$checked = true;
+		}
+		?>
+        <label>
+            <input type="checkbox" value="<?php echo esc_attr( $checkbox_value ); ?>" <?php $this->link();
+			checked( $checked ); ?> />
+			<?php $this->render_checkbox_label(); ?>
+        </label>
+		<?php
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		?>
+        <label>
+            <input type="checkbox" name="{{ data.input_name }}" value="{{ data.checkbox_value }}"
+                   id="{{ data.input_id }}" {{{ data.checked }}}/>
+            {{ data.label }}
+        </label>
+		<?php
+
+	}
+
+	/**
+	 * Fetch a checkbox value and allows overriding for separation from field value and 'default' value.
+	 *
+	 * @return string The requested checkbox value.
+	 */
+	final public function checkbox_value() {
+
+		$value = $this->value();
+
+		if ( isset( $this->checkbox_value ) ) {
+			$value = $this->checkbox_value;
+		}
+
+		return $value;
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-color-control.php
+++ b/control-types/class-wp-fields-api-color-control.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Color Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Color_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'color';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function enqueue() {
+
+		wp_enqueue_script( 'wp-color-picker' );
+		wp_enqueue_style( 'wp-color-picker' );
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		$this->input_attrs['class']              = 'color-picker-hex';
+		$this->input_attrs['placeholder']        = __( 'Hex Value' );
+		$this->input_attrs['data-default-color'] = $this->value();
+
+		?>
+        <input type="<?php echo esc_attr( $this->type ); ?>" <?php $this->input_attrs(); ?>
+               value="<?php echo esc_attr( $this->value() ); ?>" <?php $this->link(); ?> />
+		<?php
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		?>
+        <input type="<?php echo esc_attr( $this->type ); ?>" name="{{ data.input_name }}"
+               value="{{ data.value }}" id="{{ data.input_id }}" class="color-picker-hex"
+               placeholder="<?php esc_attr_e( 'Hex Value' ); ?>" data-default-color="{{ data.value }}"/>
+		<?php
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-media-control.php
+++ b/control-types/class-wp-fields-api-media-control.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Media Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Media_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'media';
+
+	/**
+	 * Media control mime type.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $mime_type = '';
+
+	/**
+	 * Button labels.
+	 *
+	 * @access public
+	 * @var array
+	 */
+	public $button_labels = array();
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function init( $object_type, $id, $args = array() ) {
+
+		parent::init( $object_type, $id, $args );
+
+		$this->button_labels = array(
+			'select'       => __( 'Select File' ),
+			'change'       => __( 'Change File' ),
+			'default'      => __( 'Default' ),
+			'remove'       => __( 'Remove' ),
+			'placeholder'  => __( 'No file selected' ),
+			'frame_title'  => __( 'Select File' ),
+			'frame_button' => __( 'Choose File' ),
+		);
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function enqueue() {
+
+		wp_enqueue_media();
+
+	}
+
+	/**
+	 * Refresh the parameters passed to the JavaScript via JSON.
+	 *
+	 * @see WP_Fields_API_Control::to_json()
+	 */
+	public function json() {
+
+		$json = parent::json();
+
+		$json['mime_type']     = $this->mime_type;
+		$json['button_labels'] = $this->button_labels;
+		$json['canUpload']     = current_user_can( 'upload_files' );
+
+		$value = $this->value();
+
+		$field = $this->field;
+
+		if ( $field ) {
+			if ( $field->default ) {
+				// Fake an attachment model - needs all fields used by template.
+				// Note that the default value must be a URL, NOT an attachment ID.
+				$type = 'document';
+
+				if ( in_array( substr( $field->default, - 3 ), array( 'jpg', 'png', 'gif', 'bmp' ) ) ) {
+					$type = 'image';
+				}
+
+				$default_attachment = array(
+					'id'    => 1,
+					'url'   => $field->default,
+					'type'  => $type,
+					'icon'  => wp_mime_type_icon( $type ),
+					'title' => basename( $field->default ),
+				);
+
+				if ( 'image' === $type ) {
+					$default_attachment['sizes'] = array(
+						'full' => array(
+							'url' => $field->default,
+						),
+					);
+				}
+
+				$json['defaultAttachment'] = $default_attachment;
+			}
+
+			if ( $value && $field->default && $value === $field->default ) {
+				// Set the default as the attachment.
+				$json['attachment'] = $json['defaultAttachment'];
+			} elseif ( $value ) {
+				$json['attachment'] = wp_prepare_attachment_for_js( $value );
+			}
+		}
+
+		return $json;
+
+	}
+
+	/**
+	 * Don't render any content for this control from PHP.
+	 *
+	 * @see WP_Fields_API_Media_Control::content_template()
+	 */
+	protected function render_content() {
+
+		// @todo Figure out render for non-JS forms
+
+	}
+
+	/**
+	 * Render a JS template for the content of the media control.
+	 */
+	public function content_template() {
+		?>
+        <label for="{{ data.settings['default'] }}-button">
+            <# if ( data.label ) { #>
+            <span class="fields-control-title">{{ data.label }}</span>
+            <# } #>
+            <# if ( data.description ) { #>
+            <span class="description fields-control-description">{{{ data.description }}}</span>
+            <# } #>
+        </label>
+
+        <# if ( data.attachment && data.attachment.id ) { #>
+        <div class="current">
+            <div class="container">
+                <div class="attachment-media-view attachment-media-view-{{ data.attachment.type }} {{ data.attachment.orientation }}">
+                    <div class="thumbnail thumbnail-{{ data.attachment.type }}">
+                        <# if ( 'image' === data.attachment.type && data.attachment.sizes &&
+                        data.attachment.sizes.medium ) { #>
+                        <img class="attachment-thumb" src="{{ data.attachment.sizes.medium.url }}" draggable="false"/>
+                        <# } else if ( 'image' === data.attachment.type && data.attachment.sizes &&
+                        data.attachment.sizes.full ) { #>
+                        <img class="attachment-thumb" src="{{ data.attachment.sizes.full.url }}" draggable="false"/>
+                        <# } else if ( 'audio' === data.attachment.type ) { #>
+                        <# if ( data.attachment.image && data.attachment.image.src && data.attachment.image.src !==
+                        data.attachment.icon ) { #>
+                        <img src="{{ data.attachment.image.src }}" class="thumbnail" draggable="false"/>
+                        <# } else { #>
+                        <img src="{{ data.attachment.icon }}" class="attachment-thumb type-icon" draggable="false"/>
+                        <# } #>
+                        <p class="attachment-meta attachment-meta-title">&#8220;{{ data.attachment.title }}&#8221;</p>
+                        <# if ( data.attachment.album || data.attachment.meta.album ) { #>
+                        <p class="attachment-meta"><em>{{ data.attachment.album || data.attachment.meta.album }}</em>
+                        </p>
+                        <# } #>
+                        <# if ( data.attachment.artist || data.attachment.meta.artist ) { #>
+                        <p class="attachment-meta">{{ data.attachment.artist || data.attachment.meta.artist }}</p>
+                        <# } #>
+                        <audio style="visibility: hidden" controls class="wp-audio-shortcode" width="100%"
+                               preload="none">
+                            <source type="{{ data.attachment.mime }}" src="{{ data.attachment.url }}"/>
+                        </audio>
+                        <# } else if ( 'video' === data.attachment.type ) { #>
+                        <div class="wp-media-wrapper wp-video">
+                            <video controls="controls" class="wp-video-shortcode" preload="metadata"
+                            <# if ( data.attachment.image && data.attachment.image.src !== data.attachment.icon ) {
+                            #>poster="{{ data.attachment.image.src }}"<# } #>>
+                            <source type="{{ data.attachment.mime }}" src="{{ data.attachment.url }}"/>
+                            </video>
+                        </div>
+                        <# } else { #>
+                        <img class="attachment-thumb type-icon icon" src="{{ data.attachment.icon }}"
+                             draggable="false"/>
+                        <p class="attachment-title">{{ data.attachment.title }}</p>
+                        <# } #>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="actions">
+            <# if ( data.canUpload ) { #>
+            <button type="button" class="button remove-button"><?php echo $this->button_labels['remove']; ?></button>
+            <button type="button" class="button upload-button"
+                    id="{{ data.settings['default'] }}-button"><?php echo $this->button_labels['change']; ?></button>
+            <div style="clear:both"></div>
+            <# } #>
+        </div>
+        <# } else { #>
+        <div class="current">
+            <div class="container">
+                <div class="placeholder">
+                    <div class="inner">
+							<span>
+								<?php echo $this->button_labels['placeholder']; ?>
+							</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="actions">
+            <# if ( data.defaultAttachment ) { #>
+            <button type="button" class="button default-button"><?php echo $this->button_labels['default']; ?></button>
+            <# } #>
+            <# if ( data.canUpload ) { #>
+            <button type="button" class="button upload-button"
+                    id="{{ data.settings['default'] }}-button"><?php echo $this->button_labels['select']; ?></button>
+            <# } #>
+            <div style="clear:both"></div>
+        </div>
+        <# } #>
+		<?php
+	}
+}

--- a/control-types/class-wp-fields-api-media-file-control.php
+++ b/control-types/class-wp-fields-api-media-file-control.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Media File Control Class.
+ *
+ * @see WP_Fields_API_Media_Control
+ */
+class WP_Fields_API_Media_File_Control extends WP_Fields_API_Media_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'media-file';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function json() {
+
+		$json = parent::json();
+
+		$value = $this->value();
+
+		if ( $value ) {
+			// Get the attachment model for the existing file.
+			$attachment_id = attachment_url_to_postid( $value );
+
+			if ( $attachment_id ) {
+				$json['attachment'] = wp_prepare_attachment_for_js( $attachment_id );
+			}
+		}
+
+		return $json;
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-multi-checkbox-control.php
+++ b/control-types/class-wp-fields-api-multi-checkbox-control.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Multiple Checkbox Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Multi_Checkbox_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'multi-checkbox';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		if ( empty( $this->choices ) ) {
+			return;
+		}
+
+		$input_attrs = $this->get_input_attrs();
+
+		$choice_attrs = array(
+			'type' => 'checkbox',
+			'name' => $input_attrs['name'] . '[]',
+		);
+
+		$current_value = $this->value();
+
+		foreach ( $this->choices as $value => $label ) :
+			$option_attrs = $choice_attrs;
+
+			$option_attrs['value'] = $value;
+
+			if ( $value == $current_value || ( is_array( $current_value ) && in_array( $value, $current_value ) ) ) {
+				$option_attrs['checked'] = 'checked';
+			}
+			?>
+            <label>
+                <input <?php $this->render_attrs( $choice_attrs );
+				$this->link(); ?> />
+				<?php echo wp_kses( $label, array(
+					'a' => array(
+						'href' => true,
+					),
+				) ); ?><br/>
+            </label>
+		<?php
+		endforeach;
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		?>
+        <# for ( key in data.options ) { var option = data.options[ key ]; #>
+        <label>
+            <input type="checkbox" name="{{ data.input_name }}[]" value="{{ option.value }}"
+                   id="{{ data.input_id }}-{{ option.id }}" {{{ option.checked }}}/>
+            {{ option.label }}
+        </label>
+        <# } #>
+		<?php
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-number-inline-description.php
+++ b/control-types/class-wp-fields-api-number-inline-description.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Number field with inline description Control class.
+ *
+ * @see WP_Fields_API_Number_Inline_Description_Control
+ */
+class WP_Fields_API_Number_Inline_Description_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'number-inline-desc';
+
+	/**
+	 * Inline text to show next to input
+	 *
+	 * @var string
+	 */
+	public $inline_text = '';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		?>
+        <input type="number" <?php $this->input_attrs(); ?>
+               value="<?php echo esc_attr( $this->value() ); ?>" <?php $this->link(); ?> />
+		<?php
+		if ( $this->inline_text ) {
+			echo '&nbsp;' . esc_attr( $this->inline_text );
+		}
+
+	}
+}

--- a/control-types/class-wp-fields-api-radio-control.php
+++ b/control-types/class-wp-fields-api-radio-control.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Radio Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Radio_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'radio';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		if ( empty( $this->choices ) ) {
+			return;
+		}
+
+		$input_attrs = $this->get_input_attrs();
+
+		$choice_attrs = array(
+			'type' => 'radio',
+			'name' => $input_attrs['name'],
+		);
+
+		$current_value = $this->value();
+
+		foreach ( $this->choices as $value => $label ) :
+			$option_attrs = $choice_attrs;
+
+			$option_attrs['value'] = $value;
+
+			if ( $value == $current_value ) {
+				$option_attrs['checked'] = 'checked';
+			}
+			?>
+            <label>
+                <input <?php $this->render_attrs( $option_attrs );
+				$this->link(); ?> />
+				<?php echo wp_kses( $label, array(
+					'a' => array(
+						'href' => true,
+					),
+				) ); ?><br/>
+            </label>
+		<?php
+		endforeach;
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		?>
+        <# for ( key in data.options ) { var option = data.options[ key ]; #>
+        <label>
+            <input type="radio" name="{{ data.input_name }}" value="{{ option.value }}"
+                   id="{{ data.input_id }}-{{ option.id }}" {{{ option.checked }}}/>
+            {{ option.label }}
+        </label>
+        <# } #>
+		<?php
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-readonly-control.php
+++ b/control-types/class-wp-fields-api-readonly-control.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Readonly Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Readonly_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'readonly';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		?>
+        <code><?php echo esc_html( $this->value() ); ?></code>
+		<?php
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		?>
+        <code>{{ data.value }}</code>
+		<?php
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-select-control.php
+++ b/control-types/class-wp-fields-api-select-control.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Select Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Select_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'select';
+
+	/**
+	 * @var string Placeholder text for choices (default "- Select -", set to null for none)
+	 */
+	public $placeholder_text = '';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		$choices = $this->choices;
+
+		$placeholder_text = $this->placeholder_text;
+
+		// Set default placeholder text
+		if ( '' === $placeholder_text ) {
+			$placeholder_text = __( '&mdash; Select &mdash;' );
+		}
+
+		// If $placeholder_text is not null, add placeholder to choices
+		if ( null !== $placeholder_text ) {
+			$choices      = array_reverse( $choices, true );
+			$choices['0'] = $placeholder_text;
+			$choices      = array_reverse( $choices, true );
+		}
+
+		if ( empty( $choices ) ) {
+			return;
+		}
+		?>
+        <select <?php $this->input_attrs(); ?> <?php $this->link(); ?>>
+			<?php
+			foreach ( $choices as $value => $label ) {
+				echo '<option value="' . esc_attr( $value ) . '"' . selected( $this->value(), $value, false ) . '>' . $label . '</option>';
+			}
+			?>
+        </select>
+		<?php
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		?>
+        <select name="{{ data.input_name }}" <# if ( data.multiple ) { #> multiple="multiple"<# } #>>
+        <# for ( key in data.options ) { var option = data.options[ key ]; #>
+        <option value="{{ option.value }}" {{{ option.selected }}}>
+            {{ option.label }}
+        </option>
+        <# } #>
+        </select>
+		<?php
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-textarea-control.php
+++ b/control-types/class-wp-fields-api-textarea-control.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Textarea Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_Textarea_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'textarea';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		?>
+        <textarea <?php $this->input_attrs(); ?> <?php $this->link(); ?>><?php echo esc_textarea( $this->value() ); ?></textarea>
+		<?php
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		?>
+        <textarea name="{{ data.input_name }}" id="{{ data.input_id }}">{{{ data.value }}}</textarea>
+		<?php
+
+	}
+
+}

--- a/control-types/class-wp-fields-api-wysiwyg-control.php
+++ b/control-types/class-wp-fields-api-wysiwyg-control.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API WYSIWYG Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_WYSIWYG_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'wysiwyg';
+
+	/**
+	 * Editor settings for use with wp_editor() third parameter
+	 *
+	 * @access public
+	 * @var array
+	 */
+	public $editor_settings = array();
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		// Get editor settings
+		$settings = $this->editor_settings;
+
+		// Get input attributes for textarea name
+		$this->input_attrs = $this->get_input_attrs();
+
+		// Set textarea name
+		$settings['textarea_name'] = $this->input_attrs['name'];
+
+		// actually render the tinyMCE box
+		wp_editor( $this->value(), $this->input_attrs['id'], $settings );
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function content_template() {
+
+		// @todo This needs further work and testing, not sure if it works right now, custom control settings don't pass through either
+
+		//$settings = array( 'textarea_name' => '{{ data.input_name }}' );
+		//wp_editor( '{{{ data.value }}}', '{{ data.input_id }}', $settings );
+
+	}
+
+}

--- a/control-types/user/class-wp-fields-api-user-capabilities-control.php
+++ b/control-types/user/class-wp-fields-api-user-capabilities-control.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API User Capabilities Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_User_Capabilities_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'user-capabilities';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		/**
+		 * @var $wp_roles WP_Roles
+		 */
+		global $wp_roles;
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		$output = array();
+
+		foreach ( $profileuser->caps as $cap => $value ) {
+			if ( ! $wp_roles->is_role( $cap ) ) {
+				if ( ! $value ) {
+					$cap = sprintf( __( 'Denied: %s' ), $cap );
+				}
+
+				$output[] = $cap;
+			}
+		}
+
+		$output = implode( ', ', $output );
+
+		echo esc_html( $output );
+
+	}
+
+}

--- a/control-types/user/class-wp-fields-api-user-display-name-control.php
+++ b/control-types/user/class-wp-fields-api-user-display-name-control.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API User Display Name Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_User_Display_Name_Control extends WP_Fields_API_Select_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'user-display-name';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function choices() {
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		$choices = array();
+
+		$choices['display_nickname'] = $profileuser->nickname;
+		$choices['display_username'] = $profileuser->user_login;
+
+		if ( ! empty( $profileuser->first_name ) ) {
+			$choices['display_firstname'] = $profileuser->first_name;
+		}
+
+		if ( ! empty( $profileuser->last_name ) ) {
+			$choices['display_lastname'] = $profileuser->last_name;
+		}
+
+		if ( ! empty( $profileuser->first_name ) && ! empty( $profileuser->last_name ) ) {
+			$choices['display_firstlast'] = $profileuser->first_name . ' ' . $profileuser->last_name;
+			$choices['display_lastfirst'] = $profileuser->last_name . ' ' . $profileuser->first_name;
+		}
+
+		// Only add this if it isn't duplicated elsewhere
+		if ( ! in_array( $profileuser->display_name, $choices ) ) {
+			$first_option = array(
+				'display_displayname' => $profileuser->display_name,
+			);
+
+			$choices = array_merge( $first_option, $choices );
+		}
+
+		$choices = array_map( 'trim', $choices );
+		$choices = array_filter( $choices );
+		$choices = array_unique( $choices );
+
+		return $choices;
+
+	}
+
+}

--- a/control-types/user/class-wp-fields-api-user-email-control.php
+++ b/control-types/user/class-wp-fields-api-user-email-control.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API User Email Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_User_Email_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'user-email';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		$current_user = get_userdata( get_current_user_id() );
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		parent::render_content();
+
+		$new_email = get_option( $current_user->ID . '_new_email' );
+
+		if ( $new_email && $new_email['newemail'] != $current_user->user_email && $profileuser->ID == $current_user->ID ) {
+			echo '<div class="updated inline"><p>';
+
+			printf( __( 'There is a pending change of your e-mail to %1$s. <a href="%2$s">Cancel</a>' ), '<code>' . $new_email['newemail'] . '</code>', esc_url( self_admin_url( 'profile.php?dismiss=' . $current_user->ID . '_new_email' ) ) );
+
+			echo '</p></div>';
+		}
+
+	}
+
+}

--- a/control-types/user/class-wp-fields-api-user-password-control.php
+++ b/control-types/user/class-wp-fields-api-user-password-control.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API User Password Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_User_Password_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'user-password';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		?>
+        <table class="form-table">
+            <tr id="password" class="user-pass1-wrap">
+                <th><label for="pass1"><?php _e( 'New Password' ); ?></label></th>
+                <td>
+                    <input class="hidden" value=" "/><!-- #24364 workaround -->
+                    <button type="button"
+                            class="button button-secondary wp-generate-pw hide-if-no-js"><?php _e( 'Generate Password' ); ?></button>
+                    <div class="wp-pwd hide-if-js">
+					<span class="password-input-wrapper">
+						<input type="password" name="pass1" id="pass1" class="regular-text" value="" autocomplete="off"
+                               data-pw="<?php echo esc_attr( wp_generate_password( 24 ) ); ?>"
+                               aria-describedby="pass-strength-result"/>
+					</span>
+                        <button type="button" class="button button-secondary wp-hide-pw hide-if-no-js" data-toggle="0"
+                                aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
+                            <span class="dashicons dashicons-hidden"></span>
+                            <span class="text"><?php _e( 'Hide' ); ?></span>
+                        </button>
+                        <button type="button" class="button button-secondary wp-cancel-pw hide-if-no-js" data-toggle="0"
+                                aria-label="<?php esc_attr_e( 'Cancel password change' ); ?>">
+                            <span class="text"><?php _e( 'Cancel' ); ?></span>
+                        </button>
+                        <div style="display:none" id="pass-strength-result" aria-live="polite"></div>
+                    </div>
+                </td>
+            </tr>
+            <tr class="user-pass2-wrap hide-if-js">
+                <th scope="row"><label for="pass2"><?php _e( 'Repeat New Password' ); ?></label></th>
+                <td>
+                    <input name="pass2" type="password" id="pass2" class="regular-text" value="" autocomplete="off"/>
+                    <p class="description"><?php _e( 'Type your new password again.' ); ?></p>
+                </td>
+            </tr>
+            <tr class="pw-weak">
+                <th><?php _e( 'Confirm Password' ); ?></th>
+                <td>
+                    <label>
+                        <input type="checkbox" name="pw_weak" class="pw-checkbox"/>
+						<?php _e( 'Confirm use of weak password' ); ?>
+                    </label>
+                </td>
+            </tr>
+        </table>
+
+        <script type="text/javascript">
+            if (window.location.hash == '#password') {
+                document.getElementById('pass1').focus();
+            }
+        </script>
+		<?php
+
+	}
+
+}

--- a/control-types/user/class-wp-fields-api-user-sessions-control.php
+++ b/control-types/user/class-wp-fields-api-user-sessions-control.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API User Sessions Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_User_Sessions_Control extends WP_Fields_API_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'user-sessions';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		/**
+		 * @var $sessions WP_User_Meta_Session_Tokens
+		 */
+		$sessions = WP_Session_Tokens::get_instance( $profileuser->ID );
+		?>
+		<?php if ( defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE && count( $sessions->get_all() ) === 1 ) : ?>
+            <div aria-live="assertive">
+                <div class="destroy-sessions">
+                    <button type="button" disabled
+                            class="button button-secondary"><?php _e( 'Log Out Everywhere Else' ); ?></button>
+                </div>
+                <p class="description">
+					<?php _e( 'You are only logged in at this location.' ); ?>
+                </p>
+            </div>
+		<?php elseif ( defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE && count( $sessions->get_all() ) > 1 ) : ?>
+            <div aria-live="assertive">
+                <div class="destroy-sessions">
+                    <button type="button" class="button button-secondary"
+                            id="destroy-sessions"><?php _e( 'Log Out Everywhere Else' ); ?></button>
+                </div>
+                <p class="description">
+					<?php _e( 'Did you lose your phone or leave your account logged in at a public computer? You can log out everywhere else, and stay logged in here.' ); ?>
+                </p>
+            </div>
+		<?php elseif ( defined( 'IS_PROFILE_PAGE' ) && ! IS_PROFILE_PAGE && $sessions->get_all() ) : ?>
+            <p>
+                <button type="button" class="button button-secondary"
+                        id="destroy-sessions"><?php _e( 'Log Out Everywhere' ); ?></button>
+            </p>
+            <p class="description">
+				<?php
+				/* translators: 1: User's display name. */
+				printf( __( 'Log %s out of all locations.' ), $profileuser->display_name );
+				?>
+            </p>
+		<?php endif; ?>
+		<?php
+
+	}
+
+}

--- a/control-types/user/class-wp-fields-api-user-super-admin-control.php
+++ b/control-types/user/class-wp-fields-api-user-super-admin-control.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API User Super Admin Control class.
+ *
+ * @see WP_Fields_API_Control
+ */
+class WP_Fields_API_User_Super_Admin_Control extends WP_Fields_API_Checkbox_Control {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'user-super-admin';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_content() {
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		if ( $profileuser->user_email == get_site_option( 'admin_email' ) && is_super_admin( $profileuser->ID ) ) {
+			echo '<p>' . __( 'Super admin privileges cannot be removed because this user has the network admin email.' ) . '</p>';
+		} else {
+			parent::render_content();
+		}
+
+	}
+
+}

--- a/datasources/class-wp-fields-api-admin-color-scheme-datasource.php
+++ b/datasources/class-wp-fields-api-admin-color-scheme-datasource.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Admin Color Scheme Datasource class.
+ *
+ * @see WP_Fields_API_Datasource
+ */
+class WP_Fields_API_Admin_Color_Scheme_Datasource extends WP_Fields_API_Datasource {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'admin-color-scheme';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setup_data( $args, $control ) {
+
+		$data = array();
+
+		/**
+		 * @var $_wp_admin_css_colors object[]
+		 */
+		global $_wp_admin_css_colors;
+
+		if ( $_wp_admin_css_colors ) {
+			ksort( $_wp_admin_css_colors );
+
+			if ( isset( $_wp_admin_css_colors['fresh'] ) ) {
+				// Set Default ('fresh') and Light should go first.
+				$_wp_admin_css_colors = array_filter( array_merge( array(
+					'fresh' => '',
+					'light' => ''
+				), $_wp_admin_css_colors ) );
+			}
+
+			foreach ( $_wp_admin_css_colors as $color => $color_info ) {
+				$data[ $color ] = $color_info->name;
+			}
+		}
+
+		return $data;
+
+	}
+
+	/**
+	 * Allow a datasource to override rendering of a control
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool Whether rendering of control has been overridden
+	 */
+	public function render_control( $control ) {
+
+		$user_id = $control->get_item_id();
+
+		/**
+		 * Fires in the 'Admin Color Scheme' section of the user editing form.
+		 *
+		 * The section is only enabled if a callback is hooked to the action,
+		 * and if there is more than one defined color scheme for the admin.
+		 *
+		 * @param int $user_id The user ID.
+		 *
+		 * @since 3.8.1 Added `$user_id` parameter.
+		 *
+		 * @since 3.0.0
+		 */
+		do_action( 'admin_color_scheme_picker', $user_id );
+
+		return true;
+
+	}
+
+}

--- a/datasources/class-wp-fields-api-comment-datasource.php
+++ b/datasources/class-wp-fields-api-comment-datasource.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Comment Datasource class.
+ *
+ * @see WP_Fields_API_Datasource
+ */
+class WP_Fields_API_Comment_Datasource extends WP_Fields_API_Datasource {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'comment';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $hierarchical = true;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $hierarchical_fields = array(
+		'id'            => 'comment_ID',
+		'parent'        => 'comment_parent',
+		'title'         => 'comment_content',
+		'default_title' => '',
+	);
+
+	/**
+	 * @var string Comment type name
+	 */
+	public $comment_type;
+
+	/**
+	 * @var bool Whether to exclude current item ID from list
+	 */
+	public $exclude_current_item_id = false;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setup_data( $args, $control ) {
+
+		$data = array();
+
+		if ( $control ) {
+			// Handle default comment type
+			if ( empty( $this->comment_type ) && 'comment' == $control->object_type && ! empty( $control->object_subtype ) ) {
+				$this->comment_type = $control->object_subtype;
+			}
+
+			// Handle exclusion
+			$item_id = $control->get_item_id();
+
+			if ( $this->exclude_current_item_id && 0 < $item_id ) {
+				if ( ! isset( $args['comment__not_in'] ) ) {
+					$args['comment__not_in'] = array();
+				}
+
+				$args['comment__not_in'][] = $item_id;
+			}
+		}
+
+		if ( $this->comment_type ) {
+			// Set comment type
+			$args['type'] = $this->comment_type;
+		}
+
+		// @todo Revisit limit later
+		$args['number'] = 100;
+
+		$items = get_comments( $args );
+
+		$data = $this->setup_data_recurse( $data, $items );
+
+		return $data;
+
+	}
+
+}

--- a/datasources/class-wp-fields-api-page-datasource.php
+++ b/datasources/class-wp-fields-api-page-datasource.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Page Datasource class.
+ *
+ * @see WP_Fields_API_Datasource
+ */
+class WP_Fields_API_Page_Datasource extends WP_Fields_API_Post_Datasource {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'page';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setup_data( $args, $control ) {
+
+		$items = get_pages( $args );
+
+		$data = $this->setup_data_recurse( array(), $items );
+
+		return $data;
+
+	}
+
+}

--- a/datasources/class-wp-fields-api-post-datasource.php
+++ b/datasources/class-wp-fields-api-post-datasource.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Post Datasource class.
+ *
+ * @see WP_Fields_API_Datasource
+ */
+class WP_Fields_API_Post_Datasource extends WP_Fields_API_Datasource {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'post';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $hierarchical = true;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $hierarchical_fields = array(
+		'id'            => 'ID',
+		'parent'        => 'post_parent',
+		'title'         => 'post_title',
+		'default_title' => '',
+	);
+
+	/**
+	 * @var string Post type name
+	 */
+	public $post_type;
+
+	/**
+	 * @var bool Whether to exclude current item ID from list
+	 */
+	public $exclude_current_item_id = false;
+
+	/**
+	 * @var bool Whether to exclude current item ID and descendants from list
+	 */
+	public $exclude_tree_current_item_id = false;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setup_data( $args, $control ) {
+
+		$data = array();
+
+		if ( $control ) {
+			// Handle default post type
+			if ( empty( $this->post_type ) && 'post' == $control->object_type && ! empty( $control->object_subtype ) ) {
+				$this->post_type = $control->object_subtype;
+			}
+
+			// Handle exclusion
+			$item_id = $control->get_item_id();
+
+			if ( $this->exclude_current_item_id && 0 < $item_id ) {
+				if ( ! isset( $args['post__not_in'] ) ) {
+					$args['post__not_in'] = array();
+				}
+
+				$args['post__not_in'][] = $item_id;
+			}
+
+			if ( $this->exclude_tree_current_item_id && 0 < $item_id ) {
+				if ( ! isset( $args['post__not_in'] ) ) {
+					$args['post_parent__not_in'] = array();
+				}
+
+				$args['post_parent__not_in'][] = $item_id;
+			}
+		}
+
+		if ( $this->post_type ) {
+			// Set post type
+			$args['post_type'] = $this->post_type;
+		} elseif ( empty( $args['post_type'] ) ) {
+			// Return empty data if no post type set
+			return $data;
+		}
+
+		// @todo Revisit limit later
+		$args['posts_per_page'] = 100;
+
+		$items = get_posts( $args );
+
+		$data = $this->setup_data_recurse( $data, $items );
+
+		return $data;
+
+	}
+
+}

--- a/datasources/class-wp-fields-api-term-datasource.php
+++ b/datasources/class-wp-fields-api-term-datasource.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API Term Datasource class.
+ *
+ * @see WP_Fields_API_Datasource
+ */
+class WP_Fields_API_Term_Datasource extends WP_Fields_API_Datasource {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'term';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $hierarchical = true;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $hierarchical_fields = array(
+		'id'            => 'term_id',
+		'parent'        => 'parent',
+		'title'         => 'name',
+		'default_title' => '',
+	);
+
+	/**
+	 * @var string Taxonomy name
+	 */
+	public $taxonomy;
+
+	/**
+	 * @var bool Whether to exclude current item ID from list
+	 */
+	public $exclude_current_item_id = false;
+
+	/**
+	 * @var bool Whether to exclude current item ID and descendants from list
+	 */
+	public $exclude_tree_current_item_id = false;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setup_data( $args, $control ) {
+
+		$data = array();
+
+		if ( $control ) {
+			// Handle default taxonomy
+			if ( empty( $this->taxonomy ) && 'term' == $control->object_type && ! empty( $control->object_subtype ) ) {
+				$this->taxonomy = $control->object_subtype;
+			}
+
+			// Handle exclusion
+			$item_id = $control->get_item_id();
+
+			if ( ! isset( $args['exclude'] ) && $this->exclude_current_item_id && 0 < $item_id ) {
+				$args['exclude'] = $item_id;
+			}
+
+			if ( ! isset( $args['exclude_tree'] ) && $this->exclude_tree_current_item_id && 0 < $item_id ) {
+				$args['exclude_tree'] = $item_id;
+			}
+		}
+
+		if ( empty( $this->taxonomy ) ) {
+			return $data;
+		}
+
+		// @todo Revisit limit later
+		$args['number'] = 100;
+
+		$items = get_terms( $this->taxonomy, $args );
+
+		$data = $this->setup_data_recurse( $data, $items );
+
+		return $data;
+
+	}
+
+}

--- a/datasources/class-wp-fields-api-user-datasource.php
+++ b/datasources/class-wp-fields-api-user-datasource.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Fields API User Datasource class.
+ *
+ * @see WP_Fields_API_Datasource
+ */
+class WP_Fields_API_User_Datasource extends WP_Fields_API_Datasource {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'user';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setup_data( $args, $control ) {
+
+		$data = array();
+
+		$fields = array(
+			'ID',
+			'user_login'
+		);
+
+		if ( ! empty( $args['fields'] ) ) {
+			$args['fields'] = array_merge( $fields, (array) $args['fields'] );
+		} else {
+			$args['fields']   = $fields;
+			$args['fields'][] = 'display_name';
+		}
+
+		$last_field = end( $args['fields'] );
+
+		$items = get_users( $args );
+
+		foreach ( $items as $item ) {
+			$display = $item->user_login;
+
+			if ( ! empty( $item->{$last_field} ) ) {
+				$display = $item->{$last_field};
+			}
+
+			$data[ $item->ID ] = $display;
+		}
+
+		return $data;
+
+	}
+
+}

--- a/forms/class-wp-fields-api-form-comment.php
+++ b/forms/class-wp-fields-api-form-comment.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This is an implementation for Fields API for the Comment editor in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Comment
+ */
+class WP_Fields_API_Form_Comment extends WP_Fields_API_Form {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $default_section_type = 'meta-box';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+
+		add_action( 'edit_comment', array( $this, 'wp_edit_comment' ), 10 );
+
+	}
+
+	/**
+	 * Save fields based on the current comment
+	 *
+	 * @param int $comment_ID
+	 */
+	public function wp_edit_comment( $comment_ID ) {
+
+		remove_action( 'edit_comment', array( $this, 'wp_edit_comment' ) );
+
+		$comment = get_comment( $comment_ID );
+
+		if ( $comment ) {
+			$this->save_fields( $comment->comment_ID, $comment->comment_type );
+		}
+
+		add_action( 'edit_comment', array( $this, 'wp_edit_comment' ), 10, 2 );
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save_fields( $item_id = null, $object_subtype = null ) {
+
+		// Save additional fields
+		return parent::save_fields( $item_id, $object_subtype );
+
+	}
+
+}

--- a/forms/class-wp-fields-api-form-post.php
+++ b/forms/class-wp-fields-api-form-post.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * This is an implementation for Fields API for the Post editor in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Post
+ */
+class WP_Fields_API_Form_Post extends WP_Fields_API_Form {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $default_section_type = 'meta-box';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+
+		add_action( 'save_post', array( $this, 'wp_save_post' ), 10, 2 );
+
+		//////////////////////
+		// Core: Post Title //
+		//////////////////////
+
+		$section_id   = 'post_title';
+		$section_args = array(
+			'label'         => __( 'Title' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Title
+		$section_args['controls']['post_title'] = array(
+			'type'                  => 'text',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'display_label'         => false,
+			'internal'              => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		////////////////////////
+		// Core: Post Content //
+		////////////////////////
+
+		$section_id   = $this->id . '_post_content';
+		$section_args = array(
+			'label'         => __( 'Post Content' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Content
+		$section_args['controls']['post_content'] = array(
+			'type'                  => 'wysiwyg',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'internal'              => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		////////////////////////
+		// Core: Post Excerpt //
+		////////////////////////
+
+		$section_id   = $this->id . '_post_excerpt';
+		$section_args = array(
+			'label'    => __( 'Excerpt' ),
+			'controls' => array(),
+		);
+
+		// Control: Excerpt
+		$section_args['controls']['post_excerpt'] = array(
+			'type'                  => 'textarea',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'description'           => sprintf( '%s <a href="https://codex.wordpress.org/Excerpt" target="_blank">%s</a>', __( 'Excerpts are optional hand-crafted summaries of your content that can be used in your theme.' ), __( 'Learn more about manual excerpts.' ) ),
+			'internal'              => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		///////////////////////////
+		// Core: Send Trackbacks //
+		///////////////////////////
+
+		$section_id   = $this->id . '_trackback_url';
+		$section_args = array(
+			'label'         => __( 'Send Trackbacks' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Send trackbacks to
+		$section_args['controls']['trackback_url'] = array(
+			'label'                 => __( 'Send trackbacks to:' ),
+			'type'                  => 'text',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'description'           => sprintf( '%s<br /><br />%s <a href="https://codex.wordpress.org/Introduction_to_Blogging#Managing_Comments" target="_blank">%s</a>%s', __( '(Separate multiple URLs with spaces)' ), __( 'Trackbacks are a way to notify legacy blog systems that you’ve linked to them. If you link other WordPress sites, they’ll be notified automatically using' ), __( 'pingbacks' ), __( ', no other action necessary.' ) ),
+			'internal'              => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		/////////////////////////
+		// Core: Custom Fields //
+		/////////////////////////
+
+		$section_id   = $this->id . '_custom_meta';
+		$section_args = array(
+			'label'    => __( 'Custom Fields' ),
+			'controls' => array(),
+		);
+
+		// Control: Custom Meta
+		$section_args['controls']['custom_meta'] = array(
+			'type'                  => 'custom_meta', // @todo Create custom meta control
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'description'           => sprintf( '%s <a href="https://codex.wordpress.org/Using_Custom_Fields" target="_blank">%s</a>', __( 'Custom fields can be used to add extra metadata to a post that you can' ), __( 'use in your theme.' ) ),
+			'internal'              => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		//////////////////////
+		// Core: Discussion //
+		//////////////////////
+
+		$section_id   = $this->id . '_discussion';
+		$section_args = array(
+			'label'         => __( 'Discussion' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Comment Status
+		$section_args['controls']['comment_status'] = array(
+			'type'                  => 'checkbox',
+			'checkbox_label'        => __( 'Allow comments.' ),
+			'checkbox_value'        => 'open',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'internal'              => true,
+			// @todo Default should be based on site settings
+		);
+
+		// Control: Ping Status
+		$section_args['controls']['ping_status'] = array(
+			'type'                  => 'checkbox',
+			'checkbox_label'        => sprintf( '%s <a href="https://codex.wordpress.org/Excerpt" target="_blank">%s</a> %s', __( 'Allow' ), __( 'trackbacks and pingbacks' ), __( 'on this page.' ) ),
+			'checkbox_value'        => 'open',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'internal'              => true,
+			// @todo Default should be based on site settings
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		/////////////////////
+		// Core: Post Name //
+		/////////////////////
+
+		$section_id   = $this->id . '_post_name';
+		$section_args = array(
+			'label'    => __( 'Slug' ),
+			'controls' => array(),
+		);
+
+		// Control: Post Name
+		$section_args['controls']['post_name'] = array(
+			'type'                  => 'text',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'internal'              => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		//////////////////
+		// Core: Author //
+		//////////////////
+
+		$section_id   = $this->id . '_post_author';
+		$section_args = array(
+			'label'    => __( 'Author' ),
+			'controls' => array(),
+		);
+
+		// Control: Author
+		$section_args['controls']['post_author'] = array(
+			'type'                  => 'select',
+			'datasource'            => array(
+				'type'     => 'user',
+				'get_args' => array(
+					'who' => 'authors',
+				),
+			),
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'internal'              => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		//////////////////
+		// Core: Format //
+		//////////////////
+
+		$section_id   = $this->id . '_post_format';
+		$section_args = array(
+			'label'    => __( 'Format' ),
+			'context'  => 'side',
+			'controls' => array(),
+		);
+
+		// Control: Format
+		$section_args['controls']['post_format'] = array(
+			'type'                  => 'radio',
+			'datasource'            => 'post-format',
+			'capabilities_callback' => array(), // @todo Add capabilities
+			'internal'              => true,
+			// @todo Label needs to be after the input
+			// @todo Inputs need classes / ids
+			// @todo Labels need classes / ids
+		);
+
+		$this->add_child( $section_id, $section_args );
+	}
+
+	/**
+	 * Save fields based on the current post
+	 *
+	 * @param int $post_id
+	 * @param WP_Post $post
+	 */
+	public function wp_save_post( $post_id, $post ) {
+
+		remove_action( 'save_post', array( $this, 'wp_save_post' ) );
+
+		$this->save_fields( $post->ID, $post->post_type );
+
+		add_action( 'save_post', array( $this, 'wp_save_post' ), 10, 2 );
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save_fields( $item_id = null, $object_subtype = null ) {
+
+		// Save additional fields
+		return parent::save_fields( $item_id, $object_subtype );
+
+	}
+
+}

--- a/forms/class-wp-fields-api-form-term-add.php
+++ b/forms/class-wp-fields-api-form-term-add.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This is an implementation for Fields API for the Term Add New form in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Term_Add
+ */
+class WP_Fields_API_Form_Term_Add extends WP_Fields_API_Form_Term {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $default_section_type = 'default';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save_fields( $item_id = null, $object_subtype = null ) {
+
+		if ( null === $object_subtype ) {
+			$object_subtype = $this->get_object_subtype();
+		}
+
+		$term_name = '';
+
+		// Get tag name
+		if ( isset( $_POST['tag-name'] ) ) {
+			$term_name = $_POST['tag-name'];
+		}
+
+		// Save new term
+		$success = wp_insert_term( $term_name, $object_subtype, $_POST );
+
+		// Return if not successful
+		if ( is_wp_error( $success ) ) {
+			return $success;
+		}
+
+		// Save additional fields
+		return parent::save_fields( $item_id, $object_subtype );
+
+	}
+
+}

--- a/forms/class-wp-fields-api-form-term.php
+++ b/forms/class-wp-fields-api-form-term.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * This is an implementation for Fields API for the Term forms in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Term
+ *
+ * @todo Switch to WP_Fields_API_Form when styles work for divs on all admin pages properly
+ */
+class WP_Fields_API_Form_Term extends WP_Fields_API_Form {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+
+		// Make sure primary term fields are registered for all term forms
+		$this->register_term_fields();
+
+		////////////////
+		// Core: Term //
+		////////////////
+
+		$section_id   = $this->id . '-main';
+		$section_args = array(
+			'label'         => __( 'Term' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Name
+		$section_args['controls'][ $this->id . '-name' ] = array(
+			'type'        => 'text',
+			'label'       => __( 'Name' ),
+			'description' => __( 'The name is how it appears on your site.' ),
+			'input_attrs' => array(
+				'name' => 'name',
+			),
+			'field'       => 'name',
+			'internal'    => true,
+			'wrap_attr'   => array(
+				'class' => 'form-required',
+			),
+		);
+
+		if ( 'term-add' == $this->id ) {
+			// Term Add New form has a different input name
+			$section_args['controls'][ $this->id . '-name' ]['input_attrs']['name'] = 'tag-name';
+		}
+
+		// Control: Slug
+		$section_args['controls'][ $this->id . '-slug' ] = array(
+			'type'                  => 'text',
+			'label'                 => __( 'Slug' ),
+			'description'           => __( 'The "slug" is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.' ),
+			'capabilities_callback' => array( $this, 'capability_is_global_terms_disabled' ),
+			'input_attrs'           => array(
+				'name' => 'slug',
+			),
+			'field'                 => 'slug',
+			'internal'              => true,
+		);
+
+		// Control: Parent
+		$control_id_parent                              = $this->id . '-parent';
+		$section_args['controls'][ $control_id_parent ] = array(
+			'type'                         => 'select',
+			'label'                        => __( 'Parent' ),
+			'datasource'                   => array(
+				'type'     => 'term',
+				'get_args' => array(
+					'taxonomy' => 'category',
+				),
+			),
+			// @todo This description is only shown for 'category' == $object_subtype
+			// @todo Generic description for taxonomies or new label for register_taxonomy?
+			'description'                  => __( 'Categories, unlike tags, can have a hierarchy. You might have a Jazz category, and under that have children categories for Bebop and Big Band. Totally optional.' ),
+			//'description'                  => __( 'This term supports hierarchy. You might have a Jazz term, and under that have children terms for Bebop and Big Band. Totally optional.' ),
+			'capabilities_callback'        => array( $this, 'capability_is_taxonomy_hierarchical' ),
+			'exclude_tree_current_item_id' => true,
+			'placeholder_text'             => __( 'None' ),
+			'input_attrs'                  => array(
+				'name' => 'parent',
+			),
+			'field'                        => 'parent',
+			'get_args'                     => array(
+				'hide_empty' => false,
+			),
+			'internal'                     => true,
+		);
+
+		// Control: Slug
+		$section_args['controls'][ $this->id . '-description' ] = array(
+			'type'        => 'textarea',
+			'label'       => __( 'Description' ),
+			'description' => __( 'The description is not prominent by default; however, some themes may show it.' ),
+			'input_attrs' => array(
+				'name' => 'description',
+				'rows' => '5',
+				'cols' => '40',
+			),
+			'field'       => 'description',
+			'internal'    => true,
+		);
+
+		// Add section
+		$this->add_child( $section_id, $section_args );
+
+		/////////////////
+		// Back-compat //
+		/////////////////
+
+		add_action( "fields_after_render_section_controls_term_{$section_id}", array(
+			$this,
+			'_compat_section_table_hooks'
+		) );
+		add_filter( "fields_control_datasource_get_args_term_{$control_id_parent}", array(
+			$this,
+			'_compat_control_parent_dropdown_hook'
+		), 10, 3 );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save_fields( $item_id = null, $object_subtype = null ) {
+
+		if ( null === $item_id ) {
+			$item_id = $this->get_item_id();
+		}
+
+		if ( null === $object_subtype ) {
+			$object_subtype = $this->get_object_subtype();
+		}
+
+		// Save term
+		$success = wp_update_term( $item_id, $object_subtype, $_POST );
+
+		// Return if not successful
+		if ( is_wp_error( $success ) ) {
+			return $success;
+		}
+
+		// Save additional fields
+		return parent::save_fields( $item_id, $object_subtype );
+
+	}
+
+	/**
+	 * Register term fields once for all term forms
+	 */
+	public function register_term_fields() {
+		global $wp_fields;
+
+		static $registered;
+
+		if ( $registered ) {
+			return;
+		}
+
+		$registered = true;
+
+		$wp_fields->add_field( $this->object_type, 'name' );
+		$wp_fields->add_field( $this->object_type, 'slug' );
+		$wp_fields->add_field( $this->object_type, 'parent' );
+		$wp_fields->add_field( $this->object_type, 'description' );
+
+	}
+
+	/**
+	 * Control hidden if global terms is enabled
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool
+	 */
+	public function capability_is_global_terms_disabled( $control ) {
+
+		return ( ! global_terms_enabled() );
+
+	}
+
+	/**
+	 * Control hidden if taxonomy is not hierarchical
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool
+	 */
+	public function capability_is_taxonomy_hierarchical( $control ) {
+
+		return is_taxonomy_hierarchical( $this->get_object_subtype() );
+
+	}
+
+	/**
+	 * Compatibility hooks needed for within <table> markup of section
+	 *
+	 * @param WP_Fields_API_Section $section
+	 */
+	public function _compat_section_table_hooks( $section ) {
+
+		if ( 'term-edit' == $this->id ) {
+			$taxonomy = $this->object_subtype;
+			$tag      = $this->get_item();
+
+			if ( 'category' == $taxonomy ) {
+				/**
+				 * Fires after the Edit Category form fields are displayed.
+				 *
+				 * @param object $tag Current category term object.
+				 *
+				 * @deprecated 3.0.0 Use {$taxonomy}_edit_form_fields instead.
+				 *
+				 * @since      2.9.0
+				 */
+				do_action( 'edit_category_form_fields', $tag );
+			} elseif ( 'link_category' == $taxonomy ) {
+				/**
+				 * Fires after the Edit Link Category form fields are displayed.
+				 *
+				 * @param object $tag Current link category term object.
+				 *
+				 * @deprecated 3.0.0 Use {$taxonomy}_edit_form_fields instead.
+				 *
+				 * @since      2.9.0
+				 */
+				do_action( 'edit_link_category_form_fields', $tag );
+			} else {
+				/**
+				 * Fires after the Edit Tag form fields are displayed.
+				 *
+				 * @param object $tag Current tag term object.
+				 *
+				 * @deprecated 3.0.0 Use {$taxonomy}_edit_form_fields instead.
+				 *
+				 * @since      2.9.0
+				 */
+				do_action( 'edit_tag_form_fields', $tag );
+			}
+
+			/**
+			 * Fires after the Edit Term form fields are displayed.
+			 *
+			 * The dynamic portion of the hook name, `$taxonomy`, refers to
+			 * the taxonomy slug.
+			 *
+			 * @param object $tag Current taxonomy term object.
+			 * @param string $taxonomy Current taxonomy slug.
+			 *
+			 * @since 3.0.0
+			 *
+			 */
+			do_action( "{$taxonomy}_edit_form_fields", $tag, $taxonomy );
+		}
+
+	}
+
+	/**
+	 * Filter the datasource args used for compatibility purposes
+	 *
+	 * @param array $args
+	 * @param WP_Fields_API_Datasource $datasource
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return array
+	 */
+	public function _compat_control_parent_dropdown_hook( $args, $datasource, $control ) {
+
+		if ( ! in_array( $this->id, array( 'term-add', 'term-edit' ) ) ) {
+			return $args;
+		}
+
+		// Determine context from form ID
+		$context = 'new';
+
+		if ( 'term-edit' == $this->id ) {
+			$context = 'edit';
+		}
+
+		$dropdown_args = array(
+			'hide_empty'       => 0,
+			'hide_if_empty'    => false,
+			'taxonomy'         => $datasource->get_args['taxonomy'],
+			'name'             => 'parent',
+			'orderby'          => 'name',
+			'hierarchical'     => true,
+			'show_option_none' => $control->placeholder_text,
+		);
+
+		/**
+		 * Filter the taxonomy parent drop-down on the Add / Edit Term page.
+		 *
+		 * @param array $dropdown_args {
+		 *                                  An array of taxonomy parent drop-down arguments.
+		 *
+		 * @type int|bool $hide_empty Whether to hide terms not attached to any posts. Default 0|false.
+		 * @type bool $hide_if_empty Whether to hide the drop-down if no terms exist. Default false.
+		 * @type string $taxonomy The taxonomy slug.
+		 * @type string $name Value of the name attribute to use for the drop-down select element.
+		 *                                      Default 'parent'.
+		 * @type string $orderby The field to order by. Default 'name'.
+		 * @type bool $hierarchical Whether the taxonomy is hierarchical. Default true.
+		 * @type string $show_option_none Label to display if there are no terms. Default 'None'.
+		 * }
+		 *
+		 * @param string $taxonomy The taxonomy slug.
+		 * @param string $context Filter context. Accepts 'new' or 'edit'.
+		 *
+		 * @since 4.2.0 Added `$context` parameter.
+		 *
+		 * @since 3.7.0
+		 */
+		$dropdown_args = apply_filters( 'taxonomy_parent_dropdown_args', $dropdown_args, $taxonomy, $context );
+
+		// name not used in args
+		unset( $dropdown_args['name'] );
+
+		// Handle show_option_none
+		if ( $dropdown_args['show_option_none'] && $control->placeholder_text !== $dropdown_args['show_option_none'] ) {
+			$control->placeholder_text = $dropdown_args['show_option_none'];
+		}
+
+		// show_option_none not used in args
+		unset( $dropdown_args['show_option_none'] );
+
+		// Merge in any other filtered args
+		$args = array_merge( $args, $dropdown_args );
+
+		return $args;
+
+	}
+
+}

--- a/forms/class-wp-fields-api-form-user-edit.php
+++ b/forms/class-wp-fields-api-form-user-edit.php
@@ -1,0 +1,750 @@
+<?php
+/**
+ * This is an implementation for Fields API for the User Edit Profile form in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_User_Edit
+ */
+class WP_Fields_API_Form_User_Edit extends WP_Fields_API_Form {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		$control_type_dir = WP_FIELDS_API_DIR . 'implementation/wp-includes/fields-api/control-types/user/';
+
+		// Include control types
+		require_once $control_type_dir . 'class-wp-fields-api-user-super-admin-control.php';
+		require_once $control_type_dir . 'class-wp-fields-api-user-display-name-control.php';
+		require_once $control_type_dir . 'class-wp-fields-api-user-email-control.php';
+		require_once $control_type_dir . 'class-wp-fields-api-user-password-control.php';
+		require_once $control_type_dir . 'class-wp-fields-api-user-sessions-control.php';
+		require_once $control_type_dir . 'class-wp-fields-api-user-capabilities-control.php';
+
+		// Register control types
+		$wp_fields->register_control_type( 'user-super-admin', 'WP_Fields_API_User_Super_Admin_Control' );
+		$wp_fields->register_control_type( 'user-display-name', 'WP_Fields_API_User_Display_Name_Control' );
+		$wp_fields->register_control_type( 'user-email', 'WP_Fields_API_User_Email_Control' );
+		$wp_fields->register_control_type( 'user-password', 'WP_Fields_API_User_Password_Control' );
+		$wp_fields->register_control_type( 'user-sessions', 'WP_Fields_API_User_Sessions_Control' );
+		$wp_fields->register_control_type( 'user-capabilities', 'WP_Fields_API_User_Capabilities_Control' );
+
+		////////////////////////////
+		// Core: Personal Options //
+		////////////////////////////
+
+		$section_id   = $this->id . '-personal-options';
+		$section_args = array(
+			'label'    => __( 'Personal Options' ),
+			'controls' => array(),
+		);
+
+		// Control: Visual Editor
+		$section_args['controls']['rich_editing'] = array(
+			'type'                  => 'checkbox',
+			'label'                 => __( 'Visual Editor' ),
+			'description'           => __( 'Disable the visual editor when writing' ),
+			'capabilities_callback' => array( $this, 'capability_is_subscriber_editing_profile' ),
+			'checkbox_value'        => 'false',
+			'field'                 => array(
+				'sanitize_callback' => array( $this, 'sanitize_rich_editing' ),
+			),
+			'internal'              => true,
+		);
+
+		// Control: Admin Color Scheme
+		$section_args['controls']['admin_color'] = array(
+			'type'                  => 'radio',
+			'datasource'            => 'admin-color-scheme',
+			'label'                 => __( 'Admin Color Scheme' ),
+			'description'           => __( 'Disable the visual editor when writing' ),
+			'capabilities_callback' => array( $this, 'capability_has_color_scheme_control' ),
+			'internal'              => true,
+		);
+
+		// Control: Keyboard Shortcuts
+		$section_args['controls']['comment_shortcuts'] = array(
+			'type'                  => 'checkbox',
+			'label'                 => __( 'Keyboard Shortcuts' ),
+			'description'           => __( 'Enable keyboard shortcuts for comment moderation.' ) . ' ' . __( '<a href="https://codex.wordpress.org/Keyboard_Shortcuts" target="_blank">More information</a>' ),
+			'capabilities_callback' => array( $this, 'capability_is_subscriber_editing_profile' ),
+			'checkbox_value'        => 'true',
+			'field'                 => array(
+				'sanitize_callback' => array( $this, 'sanitize_comment_shortcuts' ),
+			),
+			'internal'              => true,
+		);
+
+		// Control: Toolbar
+		$section_args['controls']['admin_bar_front'] = array(
+			'type'           => 'checkbox',
+			'label'          => __( 'Toolbar' ),
+			'description'    => __( 'Show Toolbar when viewing site' ),
+			'checkbox_value' => 'true',
+			'field'          => array(
+				'sanitize_callback' => array( $this, 'sanitize_admin_bar_front' ),
+			),
+			'internal'       => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		// Back-compat
+		add_action( "fields_after_render_section_controls_term_{$section_id}", array(
+			$this,
+			'_compat_section_controls_personal_options_hooks'
+		) );
+		add_action( "fields_after_render_section_term_{$section_id}", array(
+			$this,
+			'_compat_section_personal_options_hooks'
+		) );
+
+		////////////////
+		// Core: Name //
+		////////////////
+
+		$section_id   = $this->id . '-name';
+		$section_args = array(
+			'label'    => __( 'Name' ),
+			'controls' => array(),
+		);
+
+		// Control: Username
+		$section_args['controls']['user_login'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Username' ),
+			'description' => __( 'Usernames cannot be changed.' ),
+			'input_attrs' => array(
+				'disabled' => 'disabled',
+			),
+			'internal'    => true,
+		);
+
+		// Control: Role
+		$section_args['controls']['role'] = array(
+			'type'                  => 'select',
+			'label'                 => __( 'Role' ),
+			'datasource'            => 'user-role',
+			'placeholder_text'      => __( '&mdash; No role for this site &mdash;' ),
+			'capabilities_callback' => array( $this, 'capability_show_roles' ),
+			'internal'              => true,
+		);
+
+		// Control: Super Admin
+		$section_args['controls']['super_admin'] = array(
+			'type'                  => 'user-super-admin',
+			'label'                 => __( 'Super Admin' ),
+			'description'           => __( 'Grant this user super admin privileges for the Network.' ),
+			'capabilities_callback' => array( $this, 'capability_can_grant_super_admin' ),
+			'field'                 => array(
+				'value_callback' => array( $this, 'value_is_super_admin' ),
+				//'update_value_callback' => array( $this, 'update_value_is_super_admin' ), // Handled by admin page
+			),
+			'internal'              => true,
+		);
+
+		// Control: First Name
+		$section_args['controls']['first_name'] = array(
+			'type'     => 'text',
+			'label'    => __( 'First Name' ),
+			'internal' => true,
+		);
+
+		// Control: Last Name
+		$section_args['controls']['last_name'] = array(
+			'type'     => 'text',
+			'label'    => __( 'Last Name' ),
+			'internal' => true,
+		);
+
+		// Control: Nickname
+		$section_args['controls']['user_nickname'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Nickname' ),
+			'description' => __( '(required)' ),
+			// Overrides for back-compat
+			'input_attrs' => array(
+				'name' => 'nickname',
+				'id'   => 'nickname',
+			),
+			'internal'    => true,
+		);
+
+		// Control: Display name
+		$section_args['controls']['display_name'] = array(
+			'type'     => 'user-display-name',
+			'label'    => __( 'Display name publicly as' ),
+			'internal' => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		////////////////////////
+		// Core: Contact Info //
+		////////////////////////
+
+		$section_id   = $this->id . '-contact-info';
+		$section_args = array(
+			'label'    => __( 'Contact Info' ),
+			'controls' => array(),
+		);
+
+		// Control: E-mail
+		$section_args['controls']['user_email'] = array(
+			'type'        => 'user-email',
+			'label'       => __( 'E-mail' ),
+			'description' => __( '(required)' ),
+			// Overrides for back-compat
+			'input_attrs' => array(
+				'name' => 'email',
+				'id'   => 'email',
+			),
+			'internal'    => true,
+		);
+
+		// Control: Website
+		$section_args['controls']['user_url'] = array(
+			'type'     => 'text',
+			'label'    => __( 'Website' ),
+			'internal' => true,
+		);
+
+		// Controls: Contact Info for back-compat
+		$contact_methods = wp_get_user_contact_methods();
+
+		foreach ( $contact_methods as $method => $label ) {
+			/**
+			 * Filter a user contactmethod label.
+			 *
+			 * The dynamic portion of the filter hook, `$name`, refers to
+			 * each of the keys in the contactmethods array.
+			 *
+			 * @param string $label The translatable label for the contactmethod.
+			 *
+			 * @since 2.9.0
+			 *
+			 */
+			$label = apply_filters( "user_{$method}_label", $label );
+
+			$section_args['controls'][ $method ] = array(
+				'type'     => 'text',
+				'label'    => $label,
+				'internal' => true,
+			);
+		}
+
+		$this->add_child( $section_id, $section_args );
+
+		/////////////////
+		// Core: About //
+		/////////////////
+
+		$section_id   = $this->id . '-about';
+		$section_args = array(
+			'label'    => __( 'About the user' ),
+			'controls' => array(),
+		);
+
+		if ( defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE ) {
+			$section_args['label'] = __( 'About Yourself' );
+		}
+
+		// Control: Biographical Info
+		$section_args['controls']['description'] = array(
+			'type'        => 'textarea',
+			'label'       => __( 'Biographical Info' ),
+			'description' => __( 'Share a little biographical information to fill out your profile. This may be shown publicly.' ),
+			'internal'    => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		//////////////////////////////
+		// Core: Account Management //
+		//////////////////////////////
+
+		$section_id   = $this->id . '-account-management';
+		$section_args = array(
+			'label'                 => __( 'Account Management' ),
+			'capabilities_callback' => array( $this, 'capability_show_password_fields' ),
+			'controls'              => array(),
+		);
+
+		// Control: Password
+		$section_args['controls']['user_pass'] = array(
+			'type'     => 'user-password',
+			'label'    => __( 'Password' ),
+			'internal' => true,
+		);
+
+		// Control: Sessions
+		$section_args['controls']['user_pass'] = array(
+			'type'     => 'user-sessions',
+			'label'    => __( 'Sessions' ),
+			'internal' => true,
+		);
+
+		// If password fields not shown, show Sessions under About
+		// @todo Change which section this control is in if password fields not shown
+		/*if ( ! $show_password_fields ) { }*/
+
+		// Back-compat
+		add_action( "fields_after_render_section_term_{$section_id}", array(
+			$this,
+			'_compat_section_account_management_hooks'
+		) );
+
+		$this->add_child( $section_id, $section_args );
+
+		///////////////////////////////////
+		// Core: Additional Capabilities //
+		///////////////////////////////////
+
+		$section_id   = $this->id . '-additional-capabilities';
+		$section_args = array(
+			'label'                 => __( 'Additional Capabilities' ),
+			'capabilities_callback' => array( $this, 'capability_show_capabilities' ),
+			'controls'              => array(),
+		);
+
+		// Control: Capabilities
+		$section_args['controls']['capabilities'] = array(
+			'type'     => 'user-capabilities',
+			'section'  => 'additional-capabilities',
+			'label'    => __( 'Capabilities' ),
+			'internal' => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function save_fields( $item_id = null, $object_subtype = null ) {
+
+		if ( null === $item_id ) {
+			$item_id = $this->get_item_id();
+		}
+
+		/**
+		 * @var $wpdb wpdb
+		 */
+		global $wpdb;
+
+		if ( defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE ) {
+			/**
+			 * Fires before the page loads on the 'Your Profile' editing form.
+			 *
+			 * The action only fires if the current user is editing their own profile.
+			 *
+			 * @param int $user_id The user ID.
+			 *
+			 * @since 2.0.0
+			 *
+			 */
+			do_action( 'personal_options_update', $item_id );
+		} else {
+			/**
+			 * Fires before the page loads on the 'Edit User' form.
+			 *
+			 * @param int $user_id The user ID.
+			 *
+			 * @since 2.7.0
+			 *
+			 */
+			do_action( 'edit_user_profile_update', $item_id );
+		}
+
+		// Update the email address in signups, if present.
+		if ( is_multisite() ) {
+			$user = get_userdata( $item_id );
+
+			if ( $user && $user->user_login && isset( $_POST['email'] ) && is_email( $_POST['email'] ) ) {
+				$signup_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT signup_id FROM {$wpdb->signups} WHERE user_login = %s", $user->user_login ) );
+
+				if ( 0 < $signup_id ) {
+					$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE signup_id = %d", $_POST['email'], $signup_id ) );
+				}
+			}
+		}
+
+		// Update the user.
+		$errors = edit_user( $item_id );
+
+		global $super_admins;
+
+		// Grant or revoke super admin status if requested.
+		if ( ! defined( 'IS_PROFILE_PAGE' ) || ! IS_PROFILE_PAGE ) {
+			if ( is_multisite() && is_network_admin() && current_user_can( 'manage_network_options' ) && ! isset( $super_admins ) && empty( $_POST['super_admin'] ) == is_super_admin( $item_id ) ) {
+				if ( empty( $_POST['super_admin'] ) ) {
+					revoke_super_admin( $item_id );
+				} else {
+					grant_super_admin( $item_id );
+				}
+			}
+		}
+
+		// Return if not successful
+		if ( is_wp_error( $errors ) ) {
+			return $errors;
+		}
+
+		// Save additional fields
+		return parent::save_fields( $item_id, $object_subtype );
+
+	}
+
+	/**
+	 * Controls hidden if subscriber is editing their profile logic
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool
+	 */
+	public function capability_is_subscriber_editing_profile( $control ) {
+
+		$has_access = true;
+
+		if ( is_admin() ) {
+			$is_user_an_editor = ! current_user_can( 'edit_posts' ) && ! current_user_can( 'edit_pages' );
+
+			if ( $is_user_an_editor && defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE ) {
+				$has_access = false;
+			}
+		}
+
+		return $has_access;
+
+	}
+
+	/**
+	 * Control hidden if no admin css colors AND color scheme picker set.
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool
+	 */
+	public function capability_has_color_scheme_control( $control ) {
+
+		/**
+		 * @var $_wp_admin_css_colors object[]
+		 */
+		global $_wp_admin_css_colors;
+
+		$has_access = false;
+
+		if ( 1 < count( $_wp_admin_css_colors ) && has_action( 'admin_color_scheme_picker' ) ) {
+			$has_access = true;
+		}
+
+		return $has_access;
+
+	}
+
+	/**
+	 * Control only visible if editing another user outside of the network admin.
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool
+	 */
+	public function capability_show_roles( $control ) {
+
+		$has_access = false;
+
+		if ( ( defined( 'IS_PROFILE_PAGE' ) && ! IS_PROFILE_PAGE ) && ! is_network_admin() ) {
+			$has_access = true;
+		}
+
+		return $has_access;
+
+	}
+
+	/**
+	 * Control only visible if in network admin and can manage network options, as long as super_admins is not being
+	 * overridden.
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool
+	 */
+	public function capability_can_grant_super_admin( $control ) {
+
+		$profileuser = $this->get_item();
+
+		/**
+		 * @var $super_admins string[]
+		 */
+		global $super_admins;
+
+		$has_access = false;
+
+		if ( is_multisite() && is_network_admin() && ( defined( 'IS_PROFILE_PAGE' ) && ! IS_PROFILE_PAGE ) && current_user_can( 'manage_network_options' ) && ! isset( $super_admins ) && $profileuser->user_email != get_site_option( 'admin_email' ) ) {
+			$has_access = true;
+		}
+
+		return $has_access;
+
+	}
+
+	/**
+	 * Control only visible if password fields are shown.
+	 *
+	 * @param WP_Fields_API_Control $control
+	 *
+	 * @return bool
+	 */
+	public function capability_show_password_fields( $control ) {
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		/** This filter is documented in wp-admin/user-new.php */
+		$show_password_fields = apply_filters( 'show_password_fields', true, $profileuser );
+
+		$has_access = false;
+
+		if ( $show_password_fields ) {
+			$has_access = true;
+		}
+
+		return $has_access;
+
+	}
+
+	/**
+	 * Section only visible if additional capabilities can be shown and total number of capabilities are greater than
+	 * total number of roles.
+	 *
+	 * @param WP_Fields_API_Section $section
+	 *
+	 * @return bool
+	 */
+	public function capability_show_capabilities( $section ) {
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		$total_roles = count( $profileuser->roles );
+		$total_caps  = count( $profileuser->caps );
+
+		/**
+		 * Filter whether to display additional capabilities for the user.
+		 *
+		 * The 'Additional Capabilities' section will only be enabled if
+		 * the number of the user's capabilities exceeds their number of
+		 * of roles.
+		 *
+		 * @param bool $enable Whether to display the capabilities. Default true.
+		 * @param WP_User $profileuser The current WP_User object.
+		 *
+		 * @since 2.8.0
+		 *
+		 */
+		$display_capabilities = apply_filters( 'additional_capabilities_display', true, $profileuser );
+
+		$has_access = false;
+
+		if ( $total_roles < $total_caps && $display_capabilities ) {
+			$has_access = true;
+		}
+
+		return $has_access;
+
+	}
+
+	/**
+	 * Override the value of the field for whether a user is a super admin or not
+	 *
+	 * @param int $item_id
+	 * @param WP_Fields_API_Field $field
+	 *
+	 * @return mixed
+	 */
+	public function value_is_super_admin( $item_id, $field ) {
+
+		$value = 0;
+
+		if ( is_multisite() && is_super_admin() ) {
+			$value = 1;
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Override the value of the field being updated
+	 *
+	 * @param mixed $value
+	 * @param int $item_id
+	 * @param WP_Fields_API_Field $field
+	 *
+	 * @return string|WP_Error Sanitized value or error
+	 */
+	public function sanitize_rich_editing( $value, $item_id, $field ) {
+
+		if ( ! empty( $value ) && 'false' == $value ) {
+			$value = 'false';
+		} else {
+			$value = 'true';
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Override the value of the field being updated
+	 *
+	 * @param mixed $value
+	 * @param int $item_id
+	 * @param WP_Fields_API_Field $field
+	 *
+	 * @return string|WP_Error Sanitized value or error
+	 */
+	public function sanitize_admin_bar_front( $value, $item_id, $field ) {
+
+		if ( ! empty( $value ) && 'true' == $value ) {
+			$value = 'true';
+		} else {
+			$value = 'false';
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Override the value of the field being updated
+	 *
+	 * @param mixed $value
+	 * @param int $item_id
+	 * @param WP_Fields_API_Field $field
+	 *
+	 * @return string|WP_Error Sanitized value or error
+	 */
+	public function sanitize_comment_shortcuts( $value, $item_id, $field ) {
+
+		if ( ! empty( $value ) && 'true' == $value ) {
+			$value = 'true';
+		} else {
+			$value = '';
+		}
+
+		return $value;
+
+	}
+
+	/**
+	 * Override the value update of the field for whether a user is to be a super admin or not
+	 *
+	 * @param mixed $value
+	 * @param int $item_id
+	 * @param WP_Fields_API_Field $field
+	 */
+	public function update_value_is_super_admin( $value, $item_id, $field ) {
+
+		$is_super_admin = is_super_admin( $item_id );
+
+		if ( ! empty( $value ) && ! $is_super_admin ) {
+			// Make super admin if not already a super admin
+			grant_super_admin( $item_id );
+		} elseif ( $is_super_admin ) {
+			// Revoke super admin if currently a super admin
+			revoke_super_admin( $item_id );
+		}
+
+	}
+
+	/**
+	 * Personal Options compatibility hooks needed for just after <table> markup of section.
+	 *
+	 * @param WP_Fields_API_Section $section
+	 */
+	public function _compat_section_personal_options_hooks( $section ) {
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		/**
+		 * Fires at the end of the 'Personal Options' settings table on the user editing screen.
+		 *
+		 * @param WP_User $profileuser The current WP_User object.
+		 *
+		 * @since 2.7.0
+		 *
+		 */
+		do_action( 'personal_options', $profileuser );
+
+	}
+
+	/**
+	 * Personal Options compatibility hooks needed for within <table> markup of section.
+	 *
+	 * @param WP_Fields_API_Section $section
+	 */
+	public function _compat_section_controls_personal_options_hooks( $section ) {
+
+		if ( defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE ) {
+			$profileuser = get_userdata( $this->get_item_id() );
+
+			/**
+			 * Fires after the 'Personal Options' settings table on the 'Your Profile' editing screen.
+			 *
+			 * The action only fires if the current user is editing their own profile.
+			 *
+			 * @param WP_User $profileuser The current WP_User object.
+			 *
+			 * @since 2.0.0
+			 *
+			 */
+			do_action( 'profile_personal_options', $profileuser );
+		}
+
+	}
+
+	/**
+	 * Account Management compatibility hooks needed for just after <table> markup of section.
+	 *
+	 * @param WP_Fields_API_Section $section
+	 */
+	public function _compat_section_account_management_hooks( $section ) {
+
+		$profileuser = get_userdata( $this->get_item_id() );
+
+		if ( defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE ) {
+			/**
+			 * Fires after the 'About Yourself' settings table on the 'Your Profile' editing form.
+			 *
+			 * The action only fires if the current user is editing their own profile.
+			 *
+			 * @param WP_User $profileuser The current WP_User object.
+			 *
+			 * @since 2.0.0
+			 *
+			 */
+			do_action( 'show_user_profile', $profileuser );
+		} else {
+			/**
+			 * Fires after the 'About the User' settings table on the 'Edit User' form.
+			 *
+			 * @param WP_User $profileuser The current WP_User object.
+			 *
+			 * @since 2.0.0
+			 *
+			 */
+			do_action( 'edit_user_profile', $profileuser );
+		}
+
+	}
+
+}

--- a/forms/settings/class-wp-fields-api-form-settings-general.php
+++ b/forms/settings/class-wp-fields-api-form-settings-general.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * This is an implementation for Fields API for the General Settings form in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Settings_General
+ */
+class WP_Fields_API_Form_Settings_General extends WP_Fields_API_Form_Settings {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+
+		////////////////////////////
+		// Core: General Settings //
+		////////////////////////////
+
+		$section_id   = $this->id . '-options-general';
+		$section_args = array(
+			'label'         => __( 'General Settings' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Site Title
+		$section_args['controls']['blogname'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Site Title' ),
+			'input_attrs' => array(
+				'class' => 'regular-text',
+				'id'    => 'blogname',
+				'name'  => 'blogname',
+			),
+			'internal'    => true,
+		);
+
+		// Control: Tagline
+		$section_args['controls']['blogdescription'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Tagline' ),
+			'description' => __( 'In a few words, explain what this site is about.' ),
+			'input_attrs' => array(
+				'class' => 'regular-text',
+				'id'    => 'blogdescription',
+				'name'  => 'blogdescription',
+			),
+			'internal'    => true,
+		);
+
+		// Control: WordPress Address (URL)
+		$section_args['controls']['siteurl'] = array(
+			'type'                  => 'text',
+			'label'                 => __( 'WordPress Address (URL)' ),
+			'input_attrs'           => array(
+				'class' => 'regular-text code',
+				'id'    => 'siteurl',
+				'name'  => 'siteurl',
+			),
+			'capabilities_callback' => array( $this, 'capability_is_not_multisite' ),
+			'internal'              => true,
+		);
+
+		// Control: Site Address (URL)
+		$section_args['controls']['home'] = array(
+			'type'                  => 'text',
+			'label'                 => __( 'Site Address (URL)' ),
+			'input_attrs'           => array(
+				'class' => 'regular-text code',
+				'id'    => 'home',
+				'name'  => 'home',
+			),
+			'description'           => sprintf( __( 'Enter the address here if you <a href="%s">want your site home page to be different from your WordPress installation directory</a>.' ), 'https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory' ),
+			'capabilities_callback' => array( $this, 'capability_is_not_multisite' ),
+			'internal'              => true,
+		);
+
+		// Control: Email Address
+		$section_args['controls']['admin_email'] = array(
+			'type'                  => 'text',
+			'label'                 => __( 'Email Address' ),
+			'input_attrs'           => array(
+				'class' => 'regular-text ltr',
+				'id'    => 'admin_email',
+				'name'  => 'admin_email',
+			),
+			'description'           => __( 'This address is used for admin purposes, like new user notification.' ),
+			'capabilities_callback' => array( $this, 'capability_is_not_multisite' ),
+			'internal'              => true,
+		);
+
+		// Control: Email Address
+		$section_args['controls']['admin_email'] = array(
+			'type'                  => 'email',
+			'label'                 => __( 'Email Address' ),
+			'input_attrs'           => array(
+				'class' => 'regular-text ltr',
+				'id'    => 'admin_email',
+				'name'  => 'admin_email',
+			),
+			'description'           => __( 'This address is used for admin purposes, like new user notification.' ),
+			'capabilities_callback' => array( $this, 'capability_is_not_multisite' ),
+			'internal'              => true,
+		);
+
+		// Control: (New) Email Address (multisite-only)
+		$section_args['controls']['new_admin_email'] = array(
+			'type'                  => 'email',
+			'label'                 => __( 'Email Address' ),
+			'input_attrs'           => array(
+				'class' => 'regular-text ltr',
+				'id'    => 'admin_email',
+				'name'  => 'admin_email',
+			),
+			'description'           => __( 'This address is used for admin purposes. If you change this we will send you an email at your new address to confirm it. <strong>The new address will not become active until confirmed.</strong>' ),
+			'capabilities_callback' => array( $this, 'capability_is_multisite' ),
+			'internal'              => true,
+			// @todo Custom render
+		);
+
+		// Control: Membership
+		$section_args['controls']['users_can_register'] = array(
+			'type'                  => 'checkbox',
+			'label'                 => __( 'Membership' ),
+			'input_attrs'           => array(
+				'id'   => 'users_can_register',
+				'name' => 'users_can_register',
+			),
+			'checkbox_label'        => __( 'Anyone can register' ),
+			'capabilities_callback' => array( $this, 'capability_is_not_multisite' ),
+			'internal'              => true,
+		);
+
+		// Control: New User Default Role
+		$section_args['controls']['default_role'] = array(
+			'type'                  => 'user-role',
+			'label'                 => __( 'New User Default Role' ),
+			'input_attrs'           => array(
+				'id'   => 'default_role',
+				'name' => 'default_role',
+			),
+			'capabilities_callback' => array( $this, 'capability_is_not_multisite' ),
+			'internal'              => true,
+		);
+
+		// Control: Timezone
+		// @todo: Custom control for Timezones
+
+		$current_time = time();
+
+		// Control: Date Format
+		$section_args['controls']['date_format'] = array(
+			'type'        => 'radio',
+			'label'       => __( 'Date Format' ),
+			'input_attrs' => array(
+				'id'   => 'date_format',
+				'name' => 'date_format',
+			),
+			'internal'    => true,
+			'choices'     => array(
+				date_i18n( 'F j, Y', $current_time ),
+				date_i18n( 'Y-m-d', $current_time ),
+				date_i18n( 'm/d/y', $current_time ),
+				date_i18n( 'd/m/y', $current_time ),
+			),
+			// @todo Custom control type because of nested fields
+		);
+
+		// Control: Time Format
+		$section_args['controls']['time_format'] = array(
+			'type'        => 'radio',
+			'label'       => __( 'Time Format' ),
+			'description' => sprintf( '<a href="%s">' . __( 'Documentation on date and time formatting.' ) . '</a>', 'https://codex.wordpress.org/Formatting_Date_and_Time' ),
+			'input_attrs' => array(
+				'id'   => 'time_format',
+				'name' => 'time_format',
+			),
+			'internal'    => true,
+			'choices'     => array(
+				date( 'g:i a', $current_time ),
+				date( 'g:i A', $current_time ),
+				date( 'H:i', $current_time ),
+			),
+			// @todo Custom control type because of nested fields
+		);
+
+		// Control: Week Starts On
+		$section_args['controls']['start_of_week'] = array(
+			'type'        => 'select',
+			'label'       => __( 'Week Starts On' ),
+			'internal'    => true,
+			'input_attrs' => array(
+				'id'   => 'start_of_week',
+				'name' => 'start_of_week',
+			),
+			'choices'     => array(),
+		);
+
+		/**
+		 * @global WP_Locale $wp_locale
+		 */
+		global $wp_locale;
+
+		// @todo Move into choices callback
+		for ( $day_index = 0; $day_index <= 6; $day_index ++ ) {
+			$section_args['controls']['start_of_week']['choices'][ (string) $day_index ] = $wp_locale->get_weekday( $day_index );
+		}
+
+		// @todo Implement languages dropdown control
+
+		$this->add_child( $section_id, $section_args );
+	}
+
+	/**
+	 * Control only visible if WordPress is not multisite.
+	 *
+	 * @param WP_Fields_API_Control $control Control object
+	 *
+	 * @return bool
+	 */
+	public function capability_is_not_multisite( $control ) {
+
+		return ! is_multisite();
+
+	}
+
+	/**
+	 * Control only visible if WordPress is multisite.
+	 *
+	 * @param WP_Fields_API_Control $control Control object
+	 *
+	 * @return bool
+	 */
+	public function capability_is_multisite( $control ) {
+
+		return is_multisite();
+
+	}
+
+}

--- a/forms/settings/class-wp-fields-api-form-settings-permalink.php
+++ b/forms/settings/class-wp-fields-api-form-settings-permalink.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * This is an implementation for Fields API for the Permalinks form in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Settings_Permalinks
+ */
+class WP_Fields_API_Form_Settings_Permalink extends WP_Fields_API_Form_Settings {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+
+		///////////////////////////
+		// Core: Common Settings //
+		///////////////////////////
+
+		$section_id   = $this->id . '-options-permalink';
+		$section_args = array(
+			'label'       => __( 'Common Settings' ),
+			'description' => sprintf( __( 'WordPress offers you the ability to create a custom URL structure for your permalinks and archives. Custom URL structures can improve the aesthetics, usability, and forward-compatibility of your links. A <a href="%s">number of tags are available</a>, and here are some examples to get you started.' ), 'https://codex.wordpress.org/Using_Permalinks' ),
+			'controls'    => array(),
+		);
+
+		// Control: Permalink Structure
+		$section_args['controls']['selection'] = array(
+			'type'     => 'radio-multi-label',
+			'choices'  => array(
+				__( 'Plain' )            => array(
+					'value'        => '',
+					'example_text' => '<code>' . site_url( '?p=123' ) . '</code>',
+				),
+				__( 'Day and name' )     => array(
+					'value'        => '/%year%/%monthnum%/%day%/%postname%/',
+					'example_text' => '<code>' . site_url( '?p=123' ) . '</code>',
+				),
+				__( 'Month and name' )   => array(
+					'value'        => '/%year%/%monthnum%/%postname%/',
+					'example_text' => '<code>' . site_url( date( 'm/d' ) . '/sample-post/' ) . '</code>',
+				),
+				__( 'Numeric' )          => array(
+					'value'        => '/archives/%post_id%/',
+					'example_text' => '<code>' . site_url( 'archives/123/' ) . '</code>',
+				),
+				__( 'Post name' )        => array(
+					'value'        => '/%postname%/',
+					'example_text' => '<code>' . site_url( 'sample-post/ ' ) . '</code>',
+				),
+				__( 'Custom Structure' ) => array(
+					'value'        => 'custom',
+					'example_text' => '<code>' . site_url() . '</code>'
+				)
+			),
+			'internal' => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		////////////////////
+		// Core: Optional //
+		////////////////////
+
+		$section_id   = $this->id . '-options-permalink-optional';
+		$section_args = array(
+			'label'       => __( 'Optional' ),
+			'description' => sprintf( __( 'If you like, you may enter custom structures for your category and tag URLs here. For example, using <code>topics</code> as your category base would make your category links like <code>%s</code>. If you leave these blank the defaults will be used.' ), site_url( 'topics/uncategorized' ) ),
+			'controls'    => array(),
+		);
+
+		// Control: Category base
+		$section_args['controls']['category_base'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Category base' ),
+			'input_attrs' => array(
+				'id'    => 'category_base',
+				'class' => 'regular-text code',
+			),
+			'internal'    => true,
+		);
+
+		// Control: Tag base
+		$section_args['controls']['tag_base'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Tag base' ),
+			'input_attrs' => array(
+				'id'    => 'tag_base',
+				'class' => 'regular-text code',
+			),
+			'internal'    => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+	}
+}

--- a/forms/settings/class-wp-fields-api-form-settings-reading.php
+++ b/forms/settings/class-wp-fields-api-form-settings-reading.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * This is an implementation for Fields API for the Reading form in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Settings_Reading
+ */
+class WP_Fields_API_Form_Settings_Reading extends WP_Fields_API_Form_Settings {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+
+		////////////////////
+		// Core: Optional //
+		////////////////////
+
+		$section_id   = $this->id . '-options-reading';
+		$section_args = array(
+			'label'         => __( 'Reading Settings' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Front page displays
+		$section_args['controls']['show_on_front'] = array(
+			'type'        => 'radio',
+			'label'       => __( 'Front page displays' ),
+			'input_attrs' => array(
+				'id'    => 'show_on_front',
+				'class' => 'tog'
+			),
+			'choices'     => array(
+				'posts' => __( 'Your latest posts' ),
+				'pages' => sprintf( __( 'A <a href="%s">static page</a> (select below)' ), get_admin_url( 'edit.php?post_type=page' ) ),
+			),
+			'internal'    => true,
+		);
+
+		// Control: Front page displays
+		$section_args['controls']['posts_per_page'] = array(
+			'type'        => 'number-inline-desc',
+			'label'       => __( 'Blog pages show at most' ),
+			'inline_text' => 'posts',
+			'input_attrs' => array(
+				'id'    => 'posts_per_page',
+				'min'   => 1,
+				'step'  => 1,
+				'class' => 'small-text',
+			),
+			'internal'    => true,
+		);
+
+		// Control: Syndication feeds show the most recent
+		$section_args['controls']['posts_per_rss'] = array(
+			'type'        => 'number-inline-desc',
+			'label'       => __( 'Syndication feeds show the most recent' ),
+			'inline_text' => 'items',
+			'input_attrs' => array(
+				'id'    => 'posts_per_rss',
+				'min'   => 1,
+				'step'  => 1,
+				'class' => 'small-text',
+			),
+			'internal'    => true,
+		);
+
+		// text-inline-desc
+		// @todo we need a control for nested dropdowns for show on front and posts page dropdowns connected to Front Page Display
+
+		// @todo we need a control that is a text control with inline description after for posts per page and posts per page in feeds
+
+		// Control: For each article in a feed, show
+		$section_args['controls']['rss_use_excerpt'] = array(
+			'type'        => 'radio',
+			'label'       => __( 'For each article in a feed, show' ),
+			'input_attrs' => array(
+				'id' => 'rss_use_excerpt',
+			),
+			'choices'     => array(
+				'0' => __( 'Full text' ),
+				'1' => __( 'Summary' ),
+			),
+			'internal'    => true,
+		);
+
+		// Control: It is up to search engines to honor this request.
+		$section_args['controls']['blog_public'] = array(
+			'type'        => 'checkbox',
+			'label'       => __( 'Search Engine Visibility' ),
+			'description' => __( 'It is up to search engines to honor this request.' ),
+			'input_attrs' => array(
+				'id' => 'blog_public',
+			),
+			'choices'     => array(
+				'0' => __( 'Discourage search engines from indexing this site' ),
+			),
+			'internal'    => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+	}
+
+}

--- a/forms/settings/class-wp-fields-api-form-settings-writing.php
+++ b/forms/settings/class-wp-fields-api-form-settings-writing.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * This is an implementation for Fields API for the General Writing form in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Settings_Writing
+ */
+class WP_Fields_API_Form_Settings_Writing extends WP_Fields_API_Form_Settings {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setup() {
+
+		////////////////////////////
+		// Core: Writing Settings //
+		////////////////////////////
+
+		$section_id   = $this->id . '-options-writing';
+		$section_args = array(
+			'label'         => __( 'Writing Settings' ),
+			'display_label' => false,
+			'controls'      => array(),
+		);
+
+		// Control: Default Post Category
+		$section_args['controls']['default_category'] = array(
+			'type'             => 'select',
+			'label'            => __( 'Default Post Category' ),
+			'datasource'       => array(
+				'type'     => 'term',
+				'get_args' => array(
+					'taxonomy' => 'category',
+				),
+			),
+			'input_attrs'      => array(
+				'class' => 'postform',
+				'id'    => 'default_category',
+				'name'  => 'default_category',
+			),
+			'placeholder_text' => null, // Don't show placeholder option
+			'internal'         => true,
+		);
+
+		// Control: Default Post Format
+		$section_args['controls']['default_post_format'] = array(
+			'type'             => 'select',
+			'label'            => __( 'Default Post Format' ),
+			'datasource'       => 'post-format',
+			// @todo Post format needs to be filtered to set 'standard' key as '0' key, see below
+			'input_attrs'      => array(
+				'id'   => 'default_post_format',
+				'name' => 'default_post_format',
+			),
+			'placeholder_text' => null, // Don't show placeholder option
+			'internal'         => true,
+		);
+
+		/**
+		 * // @todo Post format filter to set 'standard' => '0' key
+		 * // Make 'standard' be '0' and add to the front
+		 * $choices = array_reverse( $choices, true );
+		 * $choices['0'] = $choices['standard'];
+		 * $choices = array_reverse( $choices, true );
+		 *
+		 * unset( $choices['standard'] );
+		 */
+
+		$this->add_child( $section_id, $section_args );
+
+		/////////////////////////
+		// Core: Post by Email //
+		/////////////////////////
+
+		$section_id   = $this->id . '-options-writing-post-by-email';
+		$section_args = array(
+			'label'       => __( 'Post by Email' ),
+			'description' => sprintf( __( 'To post to WordPress by email you must set up a secret email account with POP3 access. Any mail received at this address will be posted, so it’s a good idea to keep this address very secret. Here are three random strings you could use: <code>%1$s</code>, <code>%2$s</code>, <code>%3$s</code>.' ), wp_generate_password( 8, false ), wp_generate_password( 8, false ), wp_generate_password( 8, false ) ),
+			'controls'    => array(),
+		);
+
+		// Control: Mail Server
+		$section_args['controls']['mailserver_url'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Mail Server' ),
+			'input_attrs' => array(
+				'id'    => 'mailserver_url',
+				'name'  => 'mailserver_url',
+				'class' => 'regular-text code'
+			),
+			'internal'    => true,
+			// @todo Custom control type for nested fields, the mail server has a separate field for Port
+		);
+
+		// Control: Login Name
+		$section_args['controls']['mailserver_login'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Login Name' ),
+			'input_attrs' => array(
+				'id'    => 'mailserver_login',
+				'name'  => 'mailserver_login',
+				'class' => 'regular-text ltr'
+			),
+			'internal'    => true,
+		);
+
+		// Control: Password
+		$section_args['controls']['mailserver_pass'] = array(
+			'type'        => 'text',
+			'label'       => __( 'Password' ),
+			'input_attrs' => array(
+				'id'    => 'mailserver_pass',
+				'name'  => 'mailserver_pass',
+				'class' => 'regular-text ltr'
+			),
+			'internal'    => true,
+		);
+
+		// Control: Default Mail Category
+		$section_args['controls']['default_email_category'] = array(
+			'type'             => 'select',
+			'label'            => __( 'Default Mail Category' ),
+			'datasource'       => array(
+				'type'     => 'term',
+				'get_args' => array(
+					'taxonomy' => 'category',
+				),
+			),
+			'input_attrs'      => array(
+				'class' => 'postform',
+				'id'    => 'default_email_category',
+				'name'  => 'default_email_category',
+			),
+			'placeholder_text' => null, // Don't show placeholder option
+			'internal'         => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+		///////////////////////////
+		// Core: Update Services //
+		///////////////////////////
+
+		$section_id   = $this->id . '-options-writing-update-services';
+		$section_args = array(
+			'label'       => __( 'Update Services' ),
+			'description' => sprintf( __( 'When you publish a new post, WordPress automatically notifies the following site update services. For more about this, see <a href="%s">Update Services</a> on the Codex. Separate multiple service URLs with line breaks.' ), esc_url( 'https://codex.wordpress.org/Update_Services' ) ),
+			'controls'    => array(),
+		);
+
+		// Control: Update Services
+		$section_args['controls']['ping_sites'] = array(
+			'type'          => 'textarea',
+			'label'         => __( 'Update Services' ),
+			'display_label' => false,
+			'input_attrs'   => array(
+				'id'    => 'ping_sites',
+				'name'  => 'ping_sites',
+				'class' => 'large-text code',
+				'rows'  => 3
+			),
+			'internal'      => true,
+		);
+
+		$this->add_child( $section_id, $section_args );
+
+	}
+
+}

--- a/forms/settings/class-wp-fields-api-form-settings.php
+++ b/forms/settings/class-wp-fields-api-form-settings.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This is an implementation for Fields API for the Settings forms in the WordPress Dashboard
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Form_Settings
+ */
+class WP_Fields_API_Form_Settings extends WP_Fields_API_Form {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function render() {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		// Get Settings Page ID
+		$setting_page_id = $this->id;
+
+		// Remove our namespace
+		$setting_page_id = str_replace( 'settings-', '', $setting_page_id );
+
+		// Add Settings API hidden form fields and nonce
+		settings_fields( $setting_page_id );
+
+		// Render Settings API fields
+		do_settings_sections( $setting_page_id );
+
+		// Render control templates
+		add_action( 'admin_print_footer_scripts', array( $wp_fields, 'render_control_templates' ), 5 );
+
+	}
+
+}

--- a/forms/settings/class-wp-fields-api-settings-api.php
+++ b/forms/settings/class-wp-fields-api-settings-api.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This is an integration of the Settings API with the Fields API.
+ *
+ * @package    WordPress
+ * @subpackage Fields_API
+ */
+
+/**
+ * Class WP_Fields_API_Settings_API
+ */
+class WP_Fields_API_Settings_API {
+
+	public function setup() {
+
+		// Add hook
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+
+	}
+
+	public function register_settings() {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		$forms = $wp_fields->get_forms( 'settings' );
+
+		foreach ( $forms as $form ) {
+			/**
+			 * @var $sections WP_Fields_API_Section[]
+			 */
+			$sections = $form->get_children();
+
+			foreach ( $sections as $section ) {
+				if ( ! $section->check_capabilities() ) {
+					continue;
+				}
+
+				$form_id       = $form->id;
+				$section_id    = $section->id;
+				$section_title = $section->label;
+
+				// Remove our namespace
+				$setting_page_id = str_replace( 'settings-', '', $form_id );
+
+				if ( ! $section->display_label ) {
+					$section_title = '';
+				}
+
+				// Get Setting Controls
+				/**
+				 * @var $controls WP_Fields_API_Control[]
+				 */
+				$controls = $section->get_children();
+
+				if ( $controls ) {
+					$added_section = false;
+
+					foreach ( $controls as $control ) {
+						$field = $control->field;
+
+						if ( empty( $field ) ) {
+							continue;
+						}
+
+						if ( ! $control->check_capabilities() ) {
+							continue;
+						}
+
+						if ( ! $added_section ) {
+							add_settings_section(
+								$section_id,
+								$section_title,
+								array( $section, 'render_description' ),
+								$setting_page_id
+							);
+
+							$added_section = true;
+						}
+
+						$sanitize_callback = array( $field, 'sanitize' );
+
+						$field_id = $field->id;
+
+						$settings_args = array(
+							'fields_api' => true,
+							'label_for'  => $field_id,
+							'control'    => $control,
+						);
+
+						$control_label   = $control->label;
+						$render_callback = array( $this, 'render_control' );
+
+						if ( 'hidden' === $control->type ) {
+							$control_label   = null;
+							$render_callback = '__return_null';
+						}
+
+						// Add Settings API field
+						add_settings_field(
+							$field_id,
+							$control_label,
+							$render_callback,
+							$setting_page_id,
+							$section_id,
+							$settings_args
+						);
+
+						// Register Setting
+						register_setting(
+							$setting_page_id,
+							$field_id,
+							$sanitize_callback
+						);
+					}
+				}
+
+			}
+		}
+
+	}
+
+	/**
+	 * Render control for Settings API
+	 *
+	 * @param array $settings_args Settings args
+	 */
+	public function render_control( $settings_args ) {
+
+		if ( empty( $settings_args['fields_api'] ) || empty( $settings_args['control'] ) ) {
+			return;
+		}
+
+		/**
+		 * @var $control WP_Fields_API_Control
+		 */
+		$control = $settings_args['control'];
+
+		$description = trim( $control->description );
+
+		$control->maybe_render();
+
+		if ( 0 < strlen( $description ) ) {
+			?>
+            <p class="description"><?php echo wp_kses_post( $description ); ?></p>
+			<?php
+		}
+
+	}
+
+}

--- a/section-types/class-wp-fields-api-meta-box-section.php
+++ b/section-types/class-wp-fields-api-meta-box-section.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * WordPress Fields API Meta Box Section class
+ *
+ * @package    WordPress
+ * @subpackage Fields API
+ */
+
+/**
+ * Fields API Meta Box Section class. Ultimately renders controls in a div
+ *
+ * @see WP_Fields_API_Section
+ */
+class WP_Fields_API_Meta_Box_Section extends WP_Fields_API_Section {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'meta-box';
+
+	/**
+	 * Meta box context
+	 *
+	 * @var string
+	 */
+	public $mb_context = 'advanced';
+
+	/**
+	 * Add meta boxes for sections
+	 *
+	 * @param string $object_subtype Object subtype, if 'comment' then it's the comment object type
+	 * @param WP_Post|WP_Comment $object Current Object
+	 */
+	public static function add_meta_boxes( $object_subtype, $object = null ) {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		$item_id     = 0;
+		$object_type = 'post';
+
+		if ( $object ) {
+			if ( ! empty( $object->ID ) ) {
+				// Get Post ID and type
+				$item_id        = $object->ID;
+				$object_type    = 'post';
+				$object_subtype = $object->post_type;
+			} elseif ( ! empty( $object->comment_ID ) ) {
+				$item_id        = $object->comment_ID;
+				$object_type    = 'comment';
+				$object_subtype = $object->comment_type;
+
+				if ( empty( $object_subtype ) ) {
+					$object_subtype = 'comment';
+				}
+			} elseif ( 'comment' == $object_subtype ) {
+				$item_id     = $object->comment_ID;
+				$object_type = 'comment';
+			}
+		}
+
+		$form_id = $object_type . '-edit';
+
+		// Get form
+		$form = $wp_fields->get_form( $form_id );
+
+		if ( ! $form ) {
+			return;
+		}
+
+		$form->item_id        = $item_id;
+		$form->object_subtype = $object_subtype;
+
+		// Get registered sections
+		/**
+		 * @var $sections WP_Fields_API_Section[]
+		 */
+		$sections = $form->get_children();
+
+		foreach ( $sections as $section ) {
+			// Skip non meta boxes
+			if ( ! is_a( $section, 'WP_Fields_API_Meta_Box_Section' ) && ! is_a( $section, 'WP_Fields_API_Meta_Box_Table_Section' ) ) {
+				continue;
+			}
+
+			/**
+			 * @var $section WP_Fields_API_Meta_Box_Section
+			 */
+
+			// Pass Object subtype into section
+			$section->object_subtype = $object_subtype;
+
+			if ( ! $section->check_capabilities() ) {
+				continue;
+			}
+
+			// Meta boxes don't display section titles
+			$section->display_label = false;
+
+			// Set callback arguments
+			$callback_args = array(
+				'fields_api' => true,
+				'form'       => $form,
+				'section'    => $section,
+			);
+
+			// Only normal context can be used
+			if ( 'comment' == $section->object_type ) {
+				$section->mb_context = 'normal';
+			}
+
+			// Convert priority
+			$mb_priority = self::get_mb_priority( $section->priority );
+
+			// Add meta box
+			add_meta_box(
+				$section->id,
+				$section->label,
+				array( 'WP_Fields_API_Meta_Box_Section', 'render_meta_box' ),
+				null,
+				$section->mb_context,
+				$mb_priority,
+				$callback_args
+			);
+		}
+
+	}
+
+	/**
+	 * Get Meta Box Priority from Section priority
+	 *
+	 * @param $priority
+	 *
+	 * @return string
+	 */
+	public static function get_mb_priority( $priority ) {
+
+		$priorities = array(
+			'high'    => 0,
+			'core'    => 100,
+			'default' => 200,
+			'low'     => 300,
+		);
+
+		if ( in_array( $priority, $priorities ) ) {
+			if ( 240 <= $priority ) {
+				$priority = 'low';
+			} elseif ( 160 <= $priority ) {
+				$priority = 'default';
+			} elseif ( 80 <= $priority ) {
+				$priority = 'core';
+			} else {
+				$priority = 'high';
+			}
+		} else {
+			$priority = 'default';
+		}
+
+		return $priority;
+
+	}
+
+	/**
+	 * Render meta box output for section
+	 *
+	 * @param WP_Post|WP_Comment $object Current Object
+	 * @param array $box Meta box options
+	 */
+	public static function render_meta_box( $object, $box ) {
+
+		/**
+		 * @var $wp_fields WP_Fields_API
+		 */
+		global $wp_fields;
+
+		if ( empty( $box['args'] ) || empty( $box['args']['fields_api'] ) || empty( $box['args']['form'] ) || empty( $box['args']['section'] ) ) {
+			return;
+		}
+
+		/**
+		 * @var $form    WP_Fields_API_Form
+		 * @var $section WP_Fields_API_Section
+		 */
+		$form    = $box['args']['form'];
+		$section = $box['args']['section'];
+
+		$item_id        = 0;
+		$object_type    = 'post';
+		$object_subtype = null;
+
+		if ( $object ) {
+			if ( ! empty( $object->ID ) ) {
+				// Get Post ID and type
+				$item_id        = $object->ID;
+				$object_type    = 'post';
+				$object_subtype = $object->post_type;
+			} elseif ( ! empty( $object->comment_ID ) ) {
+				$item_id        = $object->comment_ID;
+				$object_type    = 'comment';
+				$object_subtype = $object->comment_type;
+
+				if ( empty( $object_subtype ) ) {
+					$object_subtype = 'comment';
+				}
+			}
+		}
+
+		$form->item           = $object;
+		$form->item_id        = $item_id;
+		$form->object_subtype = $object_subtype;
+
+		$form_nonce = $object_type . '_' . $form->id . '_' . $item_id;
+
+		wp_nonce_field( $form_nonce, 'wp_fields_api_fields_save' );
+
+		$section->maybe_render();
+
+		// Render control templates
+		if ( ! has_action( 'admin_print_footer_scripts', array( $wp_fields, 'render_control_templates' ) ) ) {
+			add_action( 'admin_print_footer_scripts', array( $wp_fields, 'render_control_templates' ), 5 );
+		}
+
+	}
+
+}

--- a/section-types/class-wp-fields-api-meta-box-table-section.php
+++ b/section-types/class-wp-fields-api-meta-box-table-section.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * WordPress Fields API Meta Box Section class
+ *
+ * @package    WordPress
+ * @subpackage Fields API
+ */
+
+/**
+ * Fields API Meta Box Table Section class. Ultimately renders controls in a table
+ *
+ * @see WP_Fields_API_Table_Section
+ */
+class WP_Fields_API_Meta_Box_Table_Section extends WP_Fields_API_Table_Section {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'meta-box-table';
+
+	/**
+	 * Meta box context
+	 *
+	 * @var string
+	 */
+	public $mb_context = 'advanced';
+
+}

--- a/section-types/class-wp-fields-api-table-section.php
+++ b/section-types/class-wp-fields-api-table-section.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WordPress Fields API Table Section class
+ *
+ * @package WordPress
+ * @subpackage Fields API
+ */
+
+/**
+ * Fields API Table Section class.
+ *
+ * @see WP_Fields_API_Section
+ */
+class WP_Fields_API_Table_Section extends WP_Fields_API_Section {
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public $type = 'table';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function render_controls() {
+
+		?>
+        <table class="form-table">
+			<?php parent::render_controls(); ?>
+        </table>
+		<?php
+
+	}
+
+	/**
+	 * Render control wrapper, label, description, and control input
+	 *
+	 * @param WP_Fields_API_Control $control Control object
+	 */
+	protected function render_control( $control ) {
+
+		$input_id = 'field-' . $control->id;
+
+		if ( isset( $control->input_attrs['id'] ) ) {
+			$input_id = $control->input_attrs['id'];
+		}
+		?>
+        <tr <?php $control->wrap_attrs(); ?>>
+            <th scope="row">
+				<?php if ( $control->label && $control->display_label ) { ?>
+                    <label for="<?php echo esc_attr( $input_id ); ?>">
+						<?php $control->render_label(); ?>
+                    </label>
+				<?php } ?>
+            </th>
+            <td>
+				<?php $control->maybe_render(); ?>
+				<?php $control->render_description(); ?>
+            </td>
+        </tr>
+		<?php
+
+	}
+
+}


### PR DESCRIPTION
This is just bringing over for reference the last Fields API work that was done in 2017 and before that was based on the Customizer API at the time.

It has not yet been updated with PHP 7+ in mind and also does not yet have JSON loading or some of the other wants that we've discussed before for registration based on need which would be a code pattern that calls for registering fields only when those fields are called on a page.

For full code docs / tests / reference, please see https://github.com/sc0ttkclark/wordpress-fields-api-2017